### PR TITLE
refactor: Return GameProviderId value object from GogFileDiscoveryService::getGameProviderId; Fix mangled test class names

### DIFF
--- a/backend/src/main/java/dev/codesoapbox/backity/core/discovery/application/GameContentDiscoveryService.java
+++ b/backend/src/main/java/dev/codesoapbox/backity/core/discovery/application/GameContentDiscoveryService.java
@@ -2,6 +2,7 @@ package dev.codesoapbox.backity.core.discovery.application;
 
 import dev.codesoapbox.backity.DoNotMutate;
 import dev.codesoapbox.backity.core.backup.application.downloadprogress.ProgressInfo;
+import dev.codesoapbox.backity.core.backup.domain.GameProviderId;
 import dev.codesoapbox.backity.core.discovery.domain.events.GameContentDiscoveryProgressChangedEvent;
 import dev.codesoapbox.backity.core.discovery.domain.events.GameContentDiscoveryStatusChangedEvent;
 import dev.codesoapbox.backity.core.discovery.domain.events.FileDiscoveredEvent;
@@ -26,7 +27,7 @@ public class GameContentDiscoveryService {
     private final GameRepository gameRepository;
     private final GameFileRepository fileRepository;
     private final DomainEventPublisher domainEventPublisher;
-    private final Map<String, Boolean> discoveryStatuses = new ConcurrentHashMap<>();
+    private final Map<GameProviderId, Boolean> discoveryStatuses = new ConcurrentHashMap<>();
 
     public GameContentDiscoveryService(List<GameProviderFileDiscoveryService> gameProviderFileDiscoveryServices,
                                        GameRepository gameRepository,
@@ -44,7 +45,7 @@ public class GameContentDiscoveryService {
         });
     }
 
-    private void publishProgressChangedEvent(DomainEventPublisher eventPublisher, String gameProviderId,
+    private void publishProgressChangedEvent(DomainEventPublisher eventPublisher, GameProviderId gameProviderId,
                                              ProgressInfo progress) {
         int percentage = progress.percentage();
         long seconds = progress.timeLeft().getSeconds();

--- a/backend/src/main/java/dev/codesoapbox/backity/core/discovery/application/GameContentDiscoveryStatus.java
+++ b/backend/src/main/java/dev/codesoapbox/backity/core/discovery/application/GameContentDiscoveryStatus.java
@@ -1,9 +1,10 @@
 package dev.codesoapbox.backity.core.discovery.application;
 
+import dev.codesoapbox.backity.core.backup.domain.GameProviderId;
 import lombok.NonNull;
 
 public record GameContentDiscoveryStatus(
-        @NonNull String gameProviderId,
+        @NonNull GameProviderId gameProviderId,
         boolean isInProgress
 ) {
 }

--- a/backend/src/main/java/dev/codesoapbox/backity/core/discovery/application/GameProviderFileDiscoveryService.java
+++ b/backend/src/main/java/dev/codesoapbox/backity/core/discovery/application/GameProviderFileDiscoveryService.java
@@ -1,5 +1,6 @@
 package dev.codesoapbox.backity.core.discovery.application;
 
+import dev.codesoapbox.backity.core.backup.domain.GameProviderId;
 import dev.codesoapbox.backity.core.gamefile.domain.GameProviderFile;
 import dev.codesoapbox.backity.core.backup.application.downloadprogress.ProgressInfo;
 
@@ -7,7 +8,7 @@ import java.util.function.Consumer;
 
 public interface GameProviderFileDiscoveryService {
 
-    String getGameProviderId();
+    GameProviderId getGameProviderId();
 
     void discoverAllFiles(Consumer<GameProviderFile> fileConsumer);
 

--- a/backend/src/main/java/dev/codesoapbox/backity/core/discovery/domain/events/GameContentDiscoveryProgressChangedEvent.java
+++ b/backend/src/main/java/dev/codesoapbox/backity/core/discovery/domain/events/GameContentDiscoveryProgressChangedEvent.java
@@ -1,10 +1,11 @@
 package dev.codesoapbox.backity.core.discovery.domain.events;
 
+import dev.codesoapbox.backity.core.backup.domain.GameProviderId;
 import dev.codesoapbox.backity.shared.domain.DomainEvent;
 import lombok.NonNull;
 
 public record GameContentDiscoveryProgressChangedEvent(
-        @NonNull String gameProviderId,
+        @NonNull GameProviderId gameProviderId,
         int percentage,
         long timeLeftSeconds
 ) implements DomainEvent {

--- a/backend/src/main/java/dev/codesoapbox/backity/core/discovery/domain/events/GameContentDiscoveryStatusChangedEvent.java
+++ b/backend/src/main/java/dev/codesoapbox/backity/core/discovery/domain/events/GameContentDiscoveryStatusChangedEvent.java
@@ -1,10 +1,11 @@
 package dev.codesoapbox.backity.core.discovery.domain.events;
 
+import dev.codesoapbox.backity.core.backup.domain.GameProviderId;
 import dev.codesoapbox.backity.shared.domain.DomainEvent;
 import lombok.NonNull;
 
 public record GameContentDiscoveryStatusChangedEvent(
-        @NonNull String gameProviderId,
+        @NonNull GameProviderId gameProviderId,
         boolean isInProgress
 ) implements DomainEvent {
 }

--- a/backend/src/main/java/dev/codesoapbox/backity/core/discovery/infrastructure/adapters/driven/messaging/ws/model/GameContentDiscoveryProgressChangedWsEventMapper.java
+++ b/backend/src/main/java/dev/codesoapbox/backity/core/discovery/infrastructure/adapters/driven/messaging/ws/model/GameContentDiscoveryProgressChangedWsEventMapper.java
@@ -1,10 +1,16 @@
 package dev.codesoapbox.backity.core.discovery.infrastructure.adapters.driven.messaging.ws.model;
 
+import dev.codesoapbox.backity.core.backup.domain.GameProviderId;
 import dev.codesoapbox.backity.core.discovery.domain.events.GameContentDiscoveryProgressChangedEvent;
 import org.mapstruct.Mapper;
 
 @Mapper
-public interface GameContentDiscoveryProgressChangedWsEventMapper {
+public abstract class GameContentDiscoveryProgressChangedWsEventMapper {
 
-    GameContentDiscoveryProgressChangedWsEvent toWsEvent(GameContentDiscoveryProgressChangedEvent domain);
+    public abstract GameContentDiscoveryProgressChangedWsEvent toWsEvent(
+            GameContentDiscoveryProgressChangedEvent domain);
+
+    protected String getValue(GameProviderId id) {
+        return id.value();
+    }
 }

--- a/backend/src/main/java/dev/codesoapbox/backity/core/discovery/infrastructure/adapters/driven/messaging/ws/model/GameContentDiscoveryStatusChangedWsEventMapper.java
+++ b/backend/src/main/java/dev/codesoapbox/backity/core/discovery/infrastructure/adapters/driven/messaging/ws/model/GameContentDiscoveryStatusChangedWsEventMapper.java
@@ -1,10 +1,15 @@
 package dev.codesoapbox.backity.core.discovery.infrastructure.adapters.driven.messaging.ws.model;
 
+import dev.codesoapbox.backity.core.backup.domain.GameProviderId;
 import dev.codesoapbox.backity.core.discovery.domain.events.GameContentDiscoveryStatusChangedEvent;
 import org.mapstruct.Mapper;
 
 @Mapper
-public interface GameContentDiscoveryStatusChangedWsEventMapper {
+public abstract class GameContentDiscoveryStatusChangedWsEventMapper {
 
-    GameContentDiscoveryStatusChangedWsEvent toWsEvent(GameContentDiscoveryStatusChangedEvent domain);
+    public abstract GameContentDiscoveryStatusChangedWsEvent toWsEvent(GameContentDiscoveryStatusChangedEvent domain);
+
+    protected String getValue(GameProviderId id) {
+        return id.value();
+    }
 }

--- a/backend/src/main/java/dev/codesoapbox/backity/core/discovery/infrastructure/adapters/driving/api/http/model/GameContentDiscoveryStatusHttpDtoMapper.java
+++ b/backend/src/main/java/dev/codesoapbox/backity/core/discovery/infrastructure/adapters/driving/api/http/model/GameContentDiscoveryStatusHttpDtoMapper.java
@@ -1,10 +1,15 @@
 package dev.codesoapbox.backity.core.discovery.infrastructure.adapters.driving.api.http.model;
 
+import dev.codesoapbox.backity.core.backup.domain.GameProviderId;
 import dev.codesoapbox.backity.core.discovery.application.GameContentDiscoveryStatus;
 import org.mapstruct.Mapper;
 
 @Mapper
-public interface GameContentDiscoveryStatusHttpDtoMapper {
+public abstract class GameContentDiscoveryStatusHttpDtoMapper {
 
-    GameContentDiscoveryStatusHttpDto toDto(GameContentDiscoveryStatus domain);
+    public abstract GameContentDiscoveryStatusHttpDto toDto(GameContentDiscoveryStatus domain);
+
+    protected String getValue(GameProviderId id) {
+        return id.value();
+    }
 }

--- a/backend/src/main/java/dev/codesoapbox/backity/gameproviders/gog/infrastructure/adapters/driven/api/embed/GogFileDiscoveryService.java
+++ b/backend/src/main/java/dev/codesoapbox/backity/gameproviders/gog/infrastructure/adapters/driven/api/embed/GogFileDiscoveryService.java
@@ -27,8 +27,8 @@ public class GogFileDiscoveryService implements GameProviderFileDiscoveryService
     private final GogGameWithFilesMapper gogGameWithFilesMapper;
     private IncrementalProgressTracker progressTracker;
 
-    public String getGameProviderId() {
-        return GogGameProviderId.get().value();
+    public GameProviderId getGameProviderId() {
+        return GogGameProviderId.get();
     }
 
     @Override

--- a/backend/src/test/java/dev/codesoapbox/backity/core/discovery/application/GameContentDiscoveryServiceTest.java
+++ b/backend/src/test/java/dev/codesoapbox/backity/core/discovery/application/GameContentDiscoveryServiceTest.java
@@ -1,5 +1,6 @@
 package dev.codesoapbox.backity.core.discovery.application;
 
+import dev.codesoapbox.backity.core.backup.domain.GameProviderId;
 import dev.codesoapbox.backity.core.discovery.domain.events.GameContentDiscoveryProgressChangedEvent;
 import dev.codesoapbox.backity.core.discovery.domain.events.GameContentDiscoveryStatusChangedEvent;
 import dev.codesoapbox.backity.core.game.domain.TestGame;
@@ -270,8 +271,8 @@ class GameContentDiscoveryServiceTest {
         }
 
         @Override
-        public String getGameProviderId() {
-            return "someGameProviderId";
+        public GameProviderId getGameProviderId() {
+            return new GameProviderId("someGameProviderId");
         }
 
         @Override

--- a/backend/src/test/java/dev/codesoapbox/backity/core/discovery/application/usecases/GetGameContentDiscoveryStatusListUseCaseTest.java
+++ b/backend/src/test/java/dev/codesoapbox/backity/core/discovery/application/usecases/GetGameContentDiscoveryStatusListUseCaseTest.java
@@ -1,5 +1,6 @@
 package dev.codesoapbox.backity.core.discovery.application.usecases;
 
+import dev.codesoapbox.backity.core.backup.domain.GameProviderId;
 import dev.codesoapbox.backity.core.discovery.application.GameContentDiscoveryStatus;
 import dev.codesoapbox.backity.core.discovery.application.GameContentDiscoveryService;
 import org.junit.jupiter.api.BeforeEach;
@@ -37,8 +38,9 @@ class GetGameContentDiscoveryStatusListUseCaseTest {
     }
 
     private List<GameContentDiscoveryStatus> mockGameContentDiscoveryStatuses() {
+        var gameProviderId = new GameProviderId("TestGameProviderId");
         List<GameContentDiscoveryStatus> statuses =
-                List.of(new GameContentDiscoveryStatus("GOG", true));
+                List.of(new GameContentDiscoveryStatus(gameProviderId, true));
         when(gameContentDiscoveryService.getStatuses())
                 .thenReturn(statuses);
 

--- a/backend/src/test/java/dev/codesoapbox/backity/core/discovery/domain/events/TestGameContentDiscoveryEvent.java
+++ b/backend/src/test/java/dev/codesoapbox/backity/core/discovery/domain/events/TestGameContentDiscoveryEvent.java
@@ -1,10 +1,11 @@
 package dev.codesoapbox.backity.core.discovery.domain.events;
 
+import dev.codesoapbox.backity.core.backup.domain.GameProviderId;
 import dev.codesoapbox.backity.core.gamefile.domain.FileSize;
 
 public final class TestGameContentDiscoveryEvent {
 
-    private static final String GAME_PROVIDER_ID = "TestGameProviderId";
+    private static final GameProviderId GAME_PROVIDER_ID = new GameProviderId("TestGameProviderId");
 
     public static FileDiscoveredEvent fileDiscovered() {
         return new FileDiscoveredEvent(

--- a/backend/src/test/java/dev/codesoapbox/backity/core/discovery/infrastructure/adapters/driven/messaging/ws/model/GameContentDiscoveryProgressChangedWsEventMapperTest.java
+++ b/backend/src/test/java/dev/codesoapbox/backity/core/discovery/infrastructure/adapters/driven/messaging/ws/model/GameContentDiscoveryProgressChangedWsEventMapperTest.java
@@ -7,7 +7,7 @@ import org.mapstruct.factory.Mappers;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-class GameContentDiscoveryProgressChangedEventUpdateWsMessageMapperTest {
+class GameContentDiscoveryProgressChangedWsEventMapperTest {
 
     private static final GameContentDiscoveryProgressChangedWsEventMapper MAPPER =
             Mappers.getMapper(GameContentDiscoveryProgressChangedWsEventMapper.class);

--- a/backend/src/test/java/dev/codesoapbox/backity/core/discovery/infrastructure/adapters/driven/messaging/ws/model/GameContentDiscoveryStatusChangedWsEventMapperTest.java
+++ b/backend/src/test/java/dev/codesoapbox/backity/core/discovery/infrastructure/adapters/driven/messaging/ws/model/GameContentDiscoveryStatusChangedWsEventMapperTest.java
@@ -7,7 +7,7 @@ import org.mapstruct.factory.Mappers;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-class GameGameContentDiscoveryStatusChangedEventChangedWsMessageMapperTest {
+class GameContentDiscoveryStatusChangedWsEventMapperTest {
 
     private static final GameContentDiscoveryStatusChangedWsEventMapper MAPPER =
             Mappers.getMapper(GameContentDiscoveryStatusChangedWsEventMapper.class);

--- a/backend/src/test/java/dev/codesoapbox/backity/core/discovery/infrastructure/adapters/driving/api/http/controllers/GetGameContentDiscoveryStatusListControllerIT.java
+++ b/backend/src/test/java/dev/codesoapbox/backity/core/discovery/infrastructure/adapters/driving/api/http/controllers/GetGameContentDiscoveryStatusListControllerIT.java
@@ -1,5 +1,6 @@
 package dev.codesoapbox.backity.core.discovery.infrastructure.adapters.driving.api.http.controllers;
 
+import dev.codesoapbox.backity.core.backup.domain.GameProviderId;
 import dev.codesoapbox.backity.core.discovery.application.GameContentDiscoveryStatus;
 import dev.codesoapbox.backity.core.discovery.application.usecases.GetGameContentDiscoveryStatusListUseCase;
 import dev.codesoapbox.backity.testing.http.annotations.ControllerTest;
@@ -26,14 +27,14 @@ class GetGameContentDiscoveryStatusListControllerIT {
 
     @Test
     void shouldGetStatuses() throws Exception {
-        var status = new GameContentDiscoveryStatus("GOG", true);
+        var status = new GameContentDiscoveryStatus(new GameProviderId("TestGameProviderId"), true);
 
         when(useCase.getStatusList())
                 .thenReturn(List.of(status));
 
         var expectedJson = """
                 [{
-                  "gameProviderId": "GOG",
+                  "gameProviderId": "TestGameProviderId",
                   "isInProgress": true
                 }]""";
 

--- a/backend/src/test/java/dev/codesoapbox/backity/core/discovery/infrastructure/adapters/driving/api/http/model/GameGameContentDiscoveryStatusChangedEventHttpDtoMapperTest.java
+++ b/backend/src/test/java/dev/codesoapbox/backity/core/discovery/infrastructure/adapters/driving/api/http/model/GameGameContentDiscoveryStatusChangedEventHttpDtoMapperTest.java
@@ -1,5 +1,6 @@
 package dev.codesoapbox.backity.core.discovery.infrastructure.adapters.driving.api.http.model;
 
+import dev.codesoapbox.backity.core.backup.domain.GameProviderId;
 import dev.codesoapbox.backity.core.discovery.application.GameContentDiscoveryStatus;
 import org.junit.jupiter.api.Test;
 import org.mapstruct.factory.Mappers;
@@ -13,7 +14,7 @@ class GameGameContentDiscoveryStatusChangedEventHttpDtoMapperTest {
 
     @Test
     void shouldMapToDto() {
-        var domain = new GameContentDiscoveryStatus("someGameProviderId", true);
+        var domain = new GameContentDiscoveryStatus(new GameProviderId("someGameProviderId"), true);
 
         GameContentDiscoveryStatusHttpDto result = MAPPER.toDto(domain);
 

--- a/backend/src/test/java/dev/codesoapbox/backity/gameproviders/gog/infrastructure/adapters/driven/api/embed/GogFileDiscoveryServiceTest.java
+++ b/backend/src/test/java/dev/codesoapbox/backity/gameproviders/gog/infrastructure/adapters/driven/api/embed/GogFileDiscoveryServiceTest.java
@@ -1,6 +1,7 @@
 package dev.codesoapbox.backity.gameproviders.gog.infrastructure.adapters.driven.api.embed;
 
 import dev.codesoapbox.backity.core.backup.application.downloadprogress.ProgressInfo;
+import dev.codesoapbox.backity.core.backup.domain.GameProviderId;
 import dev.codesoapbox.backity.core.gamefile.domain.GameProviderFile;
 import dev.codesoapbox.backity.core.gamefile.domain.TestGameProviderFile;
 import dev.codesoapbox.backity.gameproviders.gog.domain.GogGameWithFiles;
@@ -43,7 +44,7 @@ class GogFileDiscoveryServiceTest {
 
     @Test
     void shouldReturnGameProviderId() {
-        assertThat(gogFileDiscoveryService.getGameProviderId()).isEqualTo("GOG");
+        assertThat(gogFileDiscoveryService.getGameProviderId()).isEqualTo(new GameProviderId("GOG"));
     }
 
     @SuppressWarnings("UnusedReturnValue")


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated various components to use a dedicated GameProviderId type instead of plain strings for game provider identifiers, enhancing type safety and consistency across the application.
  - Changed several interfaces to abstract classes and added helper methods for improved internal mapping and conversion.
  - Renamed test classes for clarity and consistency.

- **Tests**
  - Updated tests to use the new GameProviderId type and adjusted assertions accordingly to match the refactored codebase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->