### PR TITLE
refactor: Move URL validation from GameFile to FileSource

### DIFF
--- a/backend/src/main/java/dev/codesoapbox/backity/core/backup/application/FileBackupService.java
+++ b/backend/src/main/java/dev/codesoapbox/backity/core/backup/application/FileBackupService.java
@@ -4,10 +4,10 @@ import dev.codesoapbox.backity.core.backup.application.downloadprogress.Download
 import dev.codesoapbox.backity.core.backup.application.downloadprogress.DownloadProgressFactory;
 import dev.codesoapbox.backity.core.backup.domain.GameProviderId;
 import dev.codesoapbox.backity.core.backup.domain.exceptions.FileBackupFailedException;
-import dev.codesoapbox.backity.core.storagesolution.domain.StorageSolution;
-import dev.codesoapbox.backity.core.storagesolution.domain.FilePathProvider;
 import dev.codesoapbox.backity.core.gamefile.domain.GameFile;
 import dev.codesoapbox.backity.core.gamefile.domain.GameFileRepository;
+import dev.codesoapbox.backity.core.storagesolution.domain.FilePathProvider;
+import dev.codesoapbox.backity.core.storagesolution.domain.StorageSolution;
 import lombok.extern.slf4j.Slf4j;
 
 import java.io.IOException;
@@ -48,7 +48,6 @@ public class FileBackupService {
 
         try {
             markInProgress(gameFile);
-            gameFile.validateReadyForDownload();
             String filePath = buildFilePath(gameFile);
             tryToBackUp(gameFile, filePath);
         } catch (IOException | RuntimeException e) {

--- a/backend/src/main/java/dev/codesoapbox/backity/core/gamefile/domain/FileSource.java
+++ b/backend/src/main/java/dev/codesoapbox/backity/core/gamefile/domain/FileSource.java
@@ -1,7 +1,9 @@
 package dev.codesoapbox.backity.core.gamefile.domain;
 
 import dev.codesoapbox.backity.core.backup.domain.GameProviderId;
+import dev.codesoapbox.backity.core.gamefile.domain.exceptions.FileSourceUrlEmptyException;
 import lombok.NonNull;
+import org.apache.logging.log4j.util.Strings;
 
 public record FileSource(
         @NonNull GameProviderId gameProviderId,
@@ -12,4 +14,10 @@ public record FileSource(
         @NonNull String originalFileName,
         @NonNull FileSize size
 ) {
+
+    public FileSource {
+        if (Strings.isBlank(url)) {
+            throw new FileSourceUrlEmptyException(gameProviderId);
+        }
+    }
 }

--- a/backend/src/main/java/dev/codesoapbox/backity/core/gamefile/domain/GameFile.java
+++ b/backend/src/main/java/dev/codesoapbox/backity/core/gamefile/domain/GameFile.java
@@ -107,10 +107,4 @@ public class GameFile {
     public void clearDomainEvents() {
         domainEvents.clear();
     }
-
-    public void validateReadyForDownload() {
-        if (Strings.isBlank(fileSource.url())) {
-            throw new FileSourceUrlEmptyException(id);
-        }
-    }
 }

--- a/backend/src/main/java/dev/codesoapbox/backity/core/gamefile/domain/exceptions/FileSourceUrlEmptyException.java
+++ b/backend/src/main/java/dev/codesoapbox/backity/core/gamefile/domain/exceptions/FileSourceUrlEmptyException.java
@@ -1,11 +1,11 @@
 package dev.codesoapbox.backity.core.gamefile.domain.exceptions;
 
-import dev.codesoapbox.backity.core.gamefile.domain.GameFileId;
+import dev.codesoapbox.backity.core.backup.domain.GameProviderId;
 import dev.codesoapbox.backity.shared.domain.exceptions.DomainInvariantViolationException;
 
 public class FileSourceUrlEmptyException extends DomainInvariantViolationException {
 
-    public FileSourceUrlEmptyException(GameFileId id) {
-        super("Game file url was null or empty for Game File with id: " + id.value());
+    public FileSourceUrlEmptyException(GameProviderId id) {
+        super("Url was empty for File Source with Game Provider id: " + id.value());
     }
 }

--- a/backend/src/test/java/dev/codesoapbox/backity/core/backup/application/FileBackupServiceTest.java
+++ b/backend/src/test/java/dev/codesoapbox/backity/core/backup/application/FileBackupServiceTest.java
@@ -3,15 +3,12 @@ package dev.codesoapbox.backity.core.backup.application;
 import dev.codesoapbox.backity.core.backup.application.downloadprogress.DownloadProgressFactory;
 import dev.codesoapbox.backity.core.backup.domain.GameProviderId;
 import dev.codesoapbox.backity.core.backup.domain.exceptions.FileBackupFailedException;
+import dev.codesoapbox.backity.core.gamefile.domain.*;
 import dev.codesoapbox.backity.core.storagesolution.domain.FakeUnixStorageSolution;
 import dev.codesoapbox.backity.core.storagesolution.domain.FilePathProvider;
-import dev.codesoapbox.backity.core.gamefile.domain.*;
-import dev.codesoapbox.backity.core.gamefile.domain.exceptions.FileSourceUrlEmptyException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -121,20 +118,6 @@ class FileBackupServiceTest {
                 .when(gameProviderFileBackupService).backUpFile(any(), any());
 
         return coreException;
-    }
-
-    @ParameterizedTest
-    @ValueSource(strings = {"", " "})
-    void downloadFileShouldThrowIfUrlIsEmpty(String url) {
-        GameFile gameFile = TestGameFile.discoveredBuilder()
-                .fileSource(TestFileSource.minimalGogBuilder()
-                        .url(url)
-                        .build())
-                .build();
-
-        assertThatThrownBy(() -> fileBackupService.backUpFile(gameFile))
-                .isInstanceOf(FileBackupFailedException.class)
-                .cause().isInstanceOf(FileSourceUrlEmptyException.class);
     }
 
     @Test

--- a/backend/src/test/java/dev/codesoapbox/backity/core/gamefile/domain/FileSourceTest.java
+++ b/backend/src/test/java/dev/codesoapbox/backity/core/gamefile/domain/FileSourceTest.java
@@ -1,0 +1,18 @@
+package dev.codesoapbox.backity.core.gamefile.domain;
+
+import dev.codesoapbox.backity.core.gamefile.domain.exceptions.FileSourceUrlEmptyException;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class FileSourceTest {
+
+    @Test
+    void constructorShouldThrowGivenUrlIsEmpty() {
+        TestFileSource.Builder fileSourceBuilder = TestFileSource.minimalGogBuilder()
+                .url("   ");
+
+        assertThatThrownBy(fileSourceBuilder::build)
+                .isInstanceOf(FileSourceUrlEmptyException.class);
+    }
+}

--- a/backend/src/test/java/dev/codesoapbox/backity/core/gamefile/domain/GameFileTest.java
+++ b/backend/src/test/java/dev/codesoapbox/backity/core/gamefile/domain/GameFileTest.java
@@ -6,7 +6,6 @@ import dev.codesoapbox.backity.core.backup.domain.events.FileBackupStartedEvent;
 import dev.codesoapbox.backity.core.game.domain.Game;
 import dev.codesoapbox.backity.core.game.domain.TestGame;
 import dev.codesoapbox.backity.core.gamefile.domain.exceptions.GameFileNotBackedUpException;
-import dev.codesoapbox.backity.core.gamefile.domain.exceptions.FileSourceUrlEmptyException;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.*;
@@ -124,30 +123,5 @@ class GameFileTest {
         gameFile.clearDomainEvents();
 
         assertThat(gameFile.getDomainEvents()).isEmpty();
-    }
-
-    @Test
-    void validateReadyForDownloadShouldDoNothingGivenTrue() {
-        GameFile gameFile = TestGameFile.discovered();
-
-        assertThatCode(gameFile::validateReadyForDownload)
-                .doesNotThrowAnyException();
-    }
-
-    @Test
-    void validateReadyForDownloadShouldDoNothingGivenFileSourceUrlIsBlank() {
-        GameFile gameFile = aGameFileWithABlankUrl();
-
-        assertThatThrownBy(gameFile::validateReadyForDownload)
-                .isInstanceOf(FileSourceUrlEmptyException.class)
-                .hasMessageContaining(gameFile.getId().toString());
-    }
-
-    private GameFile aGameFileWithABlankUrl() {
-        return TestGameFile.discoveredBuilder()
-                .fileSource(TestFileSource.minimalGogBuilder()
-                        .url(" ")
-                        .build())
-                .build();
     }
 }

--- a/backend/src/test/java/dev/codesoapbox/backity/core/gamefile/domain/exceptions/FileSourceUrlEmptyExceptionTest.java
+++ b/backend/src/test/java/dev/codesoapbox/backity/core/gamefile/domain/exceptions/FileSourceUrlEmptyExceptionTest.java
@@ -1,6 +1,6 @@
 package dev.codesoapbox.backity.core.gamefile.domain.exceptions;
 
-import dev.codesoapbox.backity.core.gamefile.domain.GameFileId;
+import dev.codesoapbox.backity.core.backup.domain.GameProviderId;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -9,13 +9,12 @@ class FileSourceUrlEmptyExceptionTest {
 
     @Test
     void shouldGetMessage() {
-        var id = new GameFileId("acde26d7-33c7-42ee-be16-bca91a604b48");
+        var id = new GameProviderId("TestGameProviderId");
         var exception = new FileSourceUrlEmptyException(id);
 
         String result = exception.getMessage();
 
-        var expectedResult = "Game file url was null or empty for Game File with id: " +
-                             "acde26d7-33c7-42ee-be16-bca91a604b48";
+        var expectedResult = "Url was empty for File Source with Game Provider id: TestGameProviderId";
         assertThat(result).isEqualTo(expectedResult);
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved validation to ensure file source URLs are never empty, preventing the creation of invalid file sources.
  - Error messages now reference the correct game provider when a file source URL is missing.

- **Tests**
  - Updated and added tests to verify the new validation logic for file source URLs.
  - Removed outdated tests related to the old validation approach.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->