### PR TITLE
refactor: Make FileBackup immutable

### DIFF
--- a/backend/src/main/java/dev/codesoapbox/backity/core/backup/application/FileBackupService.java
+++ b/backend/src/main/java/dev/codesoapbox/backity/core/backup/application/FileBackupService.java
@@ -111,8 +111,12 @@ public class FileBackupService {
         gameFileRepository.save(gameFile);
     }
 
-    private void markFailed(GameFile gameFile, Exception e) {
-        gameFile.markAsFailed(e.getMessage());
+    private void markFailed(GameFile gameFile, Exception exception) {
+        String message = exception.getMessage();
+        if(message == null) {
+            message = "Unknown error";
+        }
+        gameFile.markAsFailed(message);
         gameFileRepository.save(gameFile);
     }
 

--- a/backend/src/main/java/dev/codesoapbox/backity/core/backup/domain/events/FileBackupStatusChangedEvent.java
+++ b/backend/src/main/java/dev/codesoapbox/backity/core/backup/domain/events/FileBackupStatusChangedEvent.java
@@ -15,8 +15,8 @@ public record FileBackupStatusChangedEvent(
     public static FileBackupStatusChangedEvent from(GameFile gameFile) {
         return new FileBackupStatusChangedEvent(
                 gameFile.getId(),
-                gameFile.getFileBackup().getStatus(),
-                gameFile.getFileBackup().getFailedReason()
+                gameFile.getFileBackup().status(),
+                gameFile.getFileBackup().failedReason()
         );
     }
 }

--- a/backend/src/main/java/dev/codesoapbox/backity/core/gamefile/application/usecases/DeleteFileUseCase.java
+++ b/backend/src/main/java/dev/codesoapbox/backity/core/gamefile/application/usecases/DeleteFileUseCase.java
@@ -1,10 +1,9 @@
 package dev.codesoapbox.backity.core.gamefile.application.usecases;
 
-import dev.codesoapbox.backity.core.storagesolution.domain.StorageSolution;
-import dev.codesoapbox.backity.core.gamefile.domain.FileBackupStatus;
 import dev.codesoapbox.backity.core.gamefile.domain.GameFile;
 import dev.codesoapbox.backity.core.gamefile.domain.GameFileId;
 import dev.codesoapbox.backity.core.gamefile.domain.GameFileRepository;
+import dev.codesoapbox.backity.core.storagesolution.domain.StorageSolution;
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
@@ -18,13 +17,13 @@ public class DeleteFileUseCase {
         gameFile.validateIsBackedUp();
 
         deleteFile(gameFile);
-        gameFile.getFileBackup().setStatus(FileBackupStatus.DISCOVERED);
+        gameFile.markAsDiscovered();
         gameFileRepository.save(gameFile);
     }
 
 
     private void deleteFile(GameFile gameFile) {
-        String filePath = gameFile.getFileBackup().getFilePath();
+        String filePath = gameFile.getFileBackup().filePath();
         storageSolution.deleteIfExists(filePath);
     }
 }

--- a/backend/src/main/java/dev/codesoapbox/backity/core/gamefile/application/usecases/DownloadFileUseCase.java
+++ b/backend/src/main/java/dev/codesoapbox/backity/core/gamefile/application/usecases/DownloadFileUseCase.java
@@ -17,6 +17,8 @@ public class DownloadFileUseCase {
 
     public FileResource downloadFile(GameFileId gameFileId) throws FileNotFoundException {
         GameFile gameFile = gameFileRepository.getById(gameFileId);
-        return storageSolution.getFileResource(gameFile.getFileBackup().getFilePath());
+        String filePath = gameFile.getFileBackup().filePath();
+
+        return storageSolution.getFileResource(filePath);
     }
 }

--- a/backend/src/main/java/dev/codesoapbox/backity/core/gamefile/domain/FileBackup.java
+++ b/backend/src/main/java/dev/codesoapbox/backity/core/gamefile/domain/FileBackup.java
@@ -1,16 +1,54 @@
 package dev.codesoapbox.backity.core.gamefile.domain;
 
-import lombok.AllArgsConstructor;
-import lombok.Data;
 import lombok.NonNull;
+import lombok.With;
 
-@Data
-@AllArgsConstructor
-public class FileBackup {
+/**
+ * Represents a backup copy of a file in a Backup Target.
+ * <p>
+ * The file path must be updated to a temporary file after the status changes to 'in progress',
+ * but before being marked as successful.
+ * The file path should not be removed during status transitions,
+ * as this could lead to accidentally losing track of the physical file.
+ * The physical file resource must be deleted before its path is removed.
+ * Use the `withFilePath` method to manage both updates and removals.
+ */
+public record FileBackup(
+        @NonNull FileBackupStatus status,
+        String failedReason,
+        @With String filePath
+) {
 
-    @NonNull
-    private FileBackupStatus status;
+    public FileBackup {
+        if (status == FileBackupStatus.FAILED && failedReason == null) {
+            throw new IllegalArgumentException("failedReason is required");
+        }
+        if (status == FileBackupStatus.SUCCESS && filePath == null) {
+            throw new IllegalArgumentException("filePath is required");
+        }
+        if (status != FileBackupStatus.FAILED && failedReason != null) {
+            throw new IllegalArgumentException("failedReason must be null for this status");
+        }
 
-    private String failedReason;
-    private String filePath;
+    }
+
+    public FileBackup toDiscovered() {
+        return new FileBackup(FileBackupStatus.DISCOVERED, null, filePath);
+    }
+
+    public FileBackup toEnqueued() {
+        return new FileBackup(FileBackupStatus.ENQUEUED, null, filePath);
+    }
+
+    public FileBackup toInProgress() {
+        return new FileBackup(FileBackupStatus.IN_PROGRESS, null, filePath);
+    }
+
+    public FileBackup toSuccessful(String filePath) {
+        return new FileBackup(FileBackupStatus.SUCCESS, null, filePath);
+    }
+
+    public FileBackup toFailed(String failedReason) {
+        return new FileBackup(FileBackupStatus.FAILED, failedReason, filePath);
+    }
 }

--- a/backend/src/main/java/dev/codesoapbox/backity/core/gamefile/domain/GameFile.java
+++ b/backend/src/main/java/dev/codesoapbox/backity/core/gamefile/domain/GameFile.java
@@ -57,20 +57,23 @@ public class GameFile {
         );
     }
 
+    public void markAsDiscovered() {
+        fileBackup = fileBackup.toDiscovered();
+    }
+
     public void markAsEnqueued() {
-        fileBackup.setStatus(FileBackupStatus.ENQUEUED);
+        fileBackup = fileBackup.toEnqueued();
     }
 
     public void markAsFailed(String failedReason) {
-        fileBackup.setStatus(FileBackupStatus.FAILED);
-        fileBackup.setFailedReason(failedReason);
+        fileBackup = fileBackup.toFailed(failedReason);
 
         var event = new FileBackupFailedEvent(id, failedReason);
         domainEvents.add(event);
     }
 
     public void markAsInProgress() {
-        fileBackup.setStatus(FileBackupStatus.IN_PROGRESS);
+        fileBackup = fileBackup.toInProgress();
 
         var fileBackupStartedEvent = new FileBackupStartedEvent(
                 id,
@@ -79,29 +82,28 @@ public class GameFile {
                 fileSource.version(),
                 fileSource.originalFileName(),
                 fileSource.size(),
-                fileBackup.getFilePath()
+                fileBackup.filePath()
         );
         domainEvents.add(fileBackupStartedEvent);
     }
 
     public void markAsDownloaded(String filePath) {
-        fileBackup.setFilePath(filePath);
-        fileBackup.setStatus(FileBackupStatus.SUCCESS);
+        fileBackup = fileBackup.toSuccessful(filePath);
 
         var event = new FileBackupFinishedEvent(id);
         domainEvents.add(event);
     }
 
     public void updateFilePath(String filePath) {
-        fileBackup.setFilePath(filePath);
+        fileBackup = fileBackup.withFilePath(filePath);
     }
 
     public void clearFilePath() {
-        fileBackup.setFilePath(null);
+        fileBackup = fileBackup.withFilePath(null);
     }
 
     public void validateIsBackedUp() {
-        if (fileBackup.getStatus() != FileBackupStatus.SUCCESS) {
+        if (fileBackup.status() != FileBackupStatus.SUCCESS) {
             throw new GameFileNotBackedUpException(id);
         }
     }

--- a/backend/src/main/java/dev/codesoapbox/backity/core/gamefile/infrastructure/adapters/driven/persistence/jpa/GameFileJpaEntityMapper.java
+++ b/backend/src/main/java/dev/codesoapbox/backity/core/gamefile/infrastructure/adapters/driven/persistence/jpa/GameFileJpaEntityMapper.java
@@ -1,10 +1,7 @@
 package dev.codesoapbox.backity.core.gamefile.infrastructure.adapters.driven.persistence.jpa;
 
 import dev.codesoapbox.backity.core.backup.domain.GameProviderId;
-import dev.codesoapbox.backity.core.gamefile.domain.FileSize;
-import dev.codesoapbox.backity.core.gamefile.domain.FileSource;
-import dev.codesoapbox.backity.core.gamefile.domain.GameFile;
-import dev.codesoapbox.backity.core.gamefile.domain.GameFileId;
+import dev.codesoapbox.backity.core.gamefile.domain.*;
 import dev.codesoapbox.backity.core.game.domain.GameId;
 import org.mapstruct.BeanMapping;
 import org.mapstruct.Mapper;
@@ -42,6 +39,11 @@ public abstract class GameFileJpaEntityMapper {
 
     @Mapping(target = "size", source = "sizeInBytes")
     protected abstract FileSource toModel(FileSourceJpaEntity entity);
+
+    @Mapping(target = "toSuccessful", ignore = true)
+    @Mapping(target = "toFailed", ignore = true)
+    @Mapping(target = "withFilePath", ignore = true)
+    protected abstract FileBackup toModel(FileBackupJpaEntity entity);
 
     protected GameFileId toGameFileId(UUID uuid) {
         return new GameFileId(uuid);

--- a/backend/src/main/java/dev/codesoapbox/backity/core/storagesolution/domain/FileResource.java
+++ b/backend/src/main/java/dev/codesoapbox/backity/core/storagesolution/domain/FileResource.java
@@ -3,6 +3,9 @@ package dev.codesoapbox.backity.core.storagesolution.domain;
 import java.io.IOException;
 import java.io.InputStream;
 
+/**
+ * Represents a physical file resource, as it exists on disk or in memory.
+ */
 public record FileResource(
         InputStream inputStream,
         long sizeInBytes,

--- a/backend/src/main/java/dev/codesoapbox/backity/gameproviders/gog/infrastructure/adapters/driven/api/embed/GogFileBackupService.java
+++ b/backend/src/main/java/dev/codesoapbox/backity/gameproviders/gog/infrastructure/adapters/driven/api/embed/GogFileBackupService.java
@@ -28,7 +28,7 @@ public class GogFileBackupService implements GameProviderFileBackupService {
         FileSource fileSource = gameFile.getFileSource();
         TrackableFileStream fileStream =
                 gogEmbedWebClient.initializeProgressAndStreamFile(fileSource, downloadProgress);
-        String filePath = gameFile.getFileBackup().getFilePath();
+        String filePath = gameFile.getFileBackup().filePath();
         urlFileDownloader.downloadFile(fileStream, gameFile, filePath);
     }
 

--- a/backend/src/test/java/dev/codesoapbox/backity/core/backup/application/FileBackupServiceTest.java
+++ b/backend/src/test/java/dev/codesoapbox/backity/core/backup/application/FileBackupServiceTest.java
@@ -104,12 +104,12 @@ class FileBackupServiceTest {
                 .hasCause(coreException);
         assertThat(gameFile.getFileBackup())
                 .satisfies(fileBackup -> assertSoftly(softly -> {
-                    softly.assertThat(fileBackup.getStatus()).isEqualTo(FileBackupStatus.FAILED);
-                    softly.assertThat(fileBackup.getFailedReason()).isEqualTo(coreException.getMessage());
+                    softly.assertThat(fileBackup.status()).isEqualTo(FileBackupStatus.FAILED);
+                    softly.assertThat(fileBackup.failedReason()).isEqualTo(coreException.getMessage());
                 }));
         verify(gameFileRepository, times(4)).save(gameFile);
         assertThat(storageSolution.fileDeleteWasAttempted(filePath)).isTrue();
-        assertThat(gameFile.getFileBackup().getFilePath()).isNull();
+        assertThat(gameFile.getFileBackup().filePath()).isNull();
     }
 
     private IOException mockGameProviderServiceThrowsExceptionDuringBackup() throws IOException {
@@ -149,6 +149,11 @@ class FileBackupServiceTest {
         assertThatThrownBy(() -> fileBackupService.backUpFile(gameFile))
                 .isInstanceOf(FileBackupFailedException.class)
                 .cause().isInstanceOf(IOException.class);
+        assertThat(gameFile.getFileBackup())
+                .satisfies(fileBackup -> assertSoftly(softly -> {
+                    softly.assertThat(fileBackup.status()).isEqualTo(FileBackupStatus.FAILED);
+                    softly.assertThat(fileBackup.failedReason()).isEqualTo("Unknown error");
+                }));
     }
 
     private void mockFileBackupThrowsIOException() throws IOException {
@@ -184,8 +189,8 @@ class FileBackupServiceTest {
         }
 
         public void addFor(GameFile gameFile) {
-            savedFileBackupStatuses.add(gameFile.getFileBackup().getStatus());
-            savedFilePaths.add(gameFile.getFileBackup().getFilePath());
+            savedFileBackupStatuses.add(gameFile.getFileBackup().status());
+            savedFilePaths.add(gameFile.getFileBackup().filePath());
         }
     }
 }

--- a/backend/src/test/java/dev/codesoapbox/backity/core/game/infrastructure/adapters/driving/api/http/controllers/GetGamesControllerIT.java
+++ b/backend/src/test/java/dev/codesoapbox/backity/core/game/infrastructure/adapters/driving/api/http/controllers/GetGamesControllerIT.java
@@ -1,22 +1,20 @@
 package dev.codesoapbox.backity.core.game.infrastructure.adapters.driving.api.http.controllers;
 
-import dev.codesoapbox.backity.core.game.application.usecases.GetGamesWithFilesUseCase;
 import dev.codesoapbox.backity.core.game.application.GameWithFiles;
+import dev.codesoapbox.backity.core.game.application.usecases.GetGamesWithFilesUseCase;
 import dev.codesoapbox.backity.core.game.domain.Game;
 import dev.codesoapbox.backity.core.game.domain.GameId;
-import dev.codesoapbox.backity.core.gamefile.domain.GameFile;
 import dev.codesoapbox.backity.core.gamefile.domain.TestGameFile;
-import dev.codesoapbox.backity.shared.domain.TestPage;
-import dev.codesoapbox.backity.testing.http.annotations.ControllerTest;
 import dev.codesoapbox.backity.shared.domain.Page;
 import dev.codesoapbox.backity.shared.domain.Pagination;
+import dev.codesoapbox.backity.shared.domain.TestPage;
+import dev.codesoapbox.backity.testing.http.annotations.ControllerTest;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.util.List;
 
-import static java.util.Collections.singletonList;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
@@ -35,11 +33,10 @@ class GetGamesControllerIT {
     void shouldGetGames() throws Exception {
         var gameId = new GameId("5bdd248a-c3aa-487a-8479-0bfdb32f7ae5");
         var pagination = new Pagination(0, 2);
-        GameFile gameFile = TestGameFile.full();
         Page<GameWithFiles> gameWithFilesPage = TestPage.of(List.of(
                 new GameWithFiles(
                         new Game(gameId, "Test Game"),
-                        singletonList(gameFile)
+                        List.of(TestGameFile.successful(), TestGameFile.failed())
                 )), pagination);
         when(getGamesWithFilesUseCase.getGamesWithFiles(pagination))
                 .thenReturn(gameWithFilesPage);
@@ -51,26 +48,48 @@ class GetGamesControllerIT {
                             "content": [{
                                 "id": "5bdd248a-c3aa-487a-8479-0bfdb32f7ae5",
                                 "title": "Test Game",
-                                "files": [{
-                                  "id": "acde26d7-33c7-42ee-be16-bca91a604b48",
-                                  "gameId": "1eec1c19-25bf-4094-b926-84b5bb8fa281",
-                                  "fileSource": {
-                                    "gameProviderId": "GOG",
-                                    "originalGameTitle": "Game 1",
-                                    "fileTitle": "Game 1 (Installer)",
-                                    "version": "1.0.0",
-                                    "url": "/downlink/some_game/some_file",
-                                    "originalFileName": "game_1_installer.exe",
-                                    "size": "5 KB"
-                                  },
-                                  "fileBackup": {
-                                    "status": "DISCOVERED",
-                                    "failedReason": "someFailedReason",
-                                    "filePath": "someFilePath"
-                                  },
-                                  "dateCreated": "2022-04-29T14:15:53",
-                                  "dateModified": "2023-04-29T14:15:53"
-                                }]
+                                "files": [
+                                    {
+                                      "id": "acde26d7-33c7-42ee-be16-bca91a604b48",
+                                      "gameId": "1eec1c19-25bf-4094-b926-84b5bb8fa281",
+                                      "fileSource": {
+                                        "gameProviderId": "GOG",
+                                        "originalGameTitle": "Game 1",
+                                        "fileTitle": "Game 1 (Installer)",
+                                        "version": "1.0.0",
+                                        "url": "/downlink/some_game/some_file",
+                                        "originalFileName": "game_1_installer.exe",
+                                        "size": "5 KB"
+                                      },
+                                      "fileBackup": {
+                                        "status": "SUCCESS",
+                                        "failedReason": null,
+                                        "filePath": "someFilePath"
+                                      },
+                                      "dateCreated": "2022-04-29T14:15:53",
+                                      "dateModified": "2023-04-29T14:15:53"
+                                    },
+                                    {
+                                      "id": "acde26d7-33c7-42ee-be16-bca91a604b48",
+                                      "gameId": "1eec1c19-25bf-4094-b926-84b5bb8fa281",
+                                      "fileSource": {
+                                        "gameProviderId": "GOG",
+                                        "originalGameTitle": "Game 1",
+                                        "fileTitle": "Game 1 (Installer)",
+                                        "version": "1.0.0",
+                                        "url": "/downlink/some_game/some_file",
+                                        "originalFileName": "game_1_installer.exe",
+                                        "size": "5 KB"
+                                      },
+                                      "fileBackup": {
+                                        "status": "FAILED",
+                                        "failedReason": "someFailedReason",
+                                        "filePath": null
+                                      },
+                                      "dateCreated": "2022-04-29T14:15:53",
+                                      "dateModified": "2023-04-29T14:15:53"
+                                    }
+                                ]
                             }]
                         }
                         """));

--- a/backend/src/test/java/dev/codesoapbox/backity/core/game/infrastructure/adapters/driving/api/http/model/GameWithFilesHttpDtoMapperTest.java
+++ b/backend/src/test/java/dev/codesoapbox/backity/core/game/infrastructure/adapters/driving/api/http/model/GameWithFilesHttpDtoMapperTest.java
@@ -21,27 +21,35 @@ class GameWithFilesHttpDtoMapperTest {
     private static final GameWithFilesHttpDtoMapper MAPPER = Mappers.getMapper(GameWithFilesHttpDtoMapper.class);
 
     @Test
-    void shouldMapToDto() {
-        GameWithFiles model = domainObject();
+    void shouldMapSuccessfulToDto() {
+        GameWithFiles model = domainObjectSuccessful();
 
         GameWithFilesHttpDto result = MAPPER.toDto(model);
 
-        var expectedResult = dto();
+        var expectedResult = dtoSuccessful();
         assertThat(result)
                 .usingRecursiveComparison().isEqualTo(expectedResult);
     }
 
-    private GameWithFiles domainObject() {
+    private GameWithFiles domainObjectSuccessful() {
         Game game = TestGame.any();
         return new GameWithFiles(
                 game,
-                singletonList(TestGameFile.fullBuilder()
+                singletonList(TestGameFile.successfulBuilder()
                         .gameId(game.getId())
                         .build())
         );
     }
 
-    private GameWithFilesHttpDto dto() {
+    private GameWithFilesHttpDto dtoSuccessful() {
+        return dto(new FileBackupHttpDto(
+                FileBackupStatusHttpDto.SUCCESS,
+                null,
+                "someFilePath"
+        ));
+    }
+
+    private GameWithFilesHttpDto dto(FileBackupHttpDto fileBackupHttpDto) {
         return new GameWithFilesHttpDto(
                 "5bdd248a-c3aa-487a-8479-0bfdb32f7ae5",
                 "Test Game",
@@ -58,16 +66,41 @@ class GameWithFilesHttpDtoMapperTest {
                                         "game_1_installer.exe",
                                         "5 KB"
                                 ),
-                                new FileBackupHttpDto(
-                                        FileBackupStatusHttpDto.DISCOVERED,
-                                        "someFailedReason",
-                                        "someFilePath"
-                                ),
+                                fileBackupHttpDto,
                                 LocalDateTime.parse("2022-04-29T14:15:53"),
                                 LocalDateTime.parse("2023-04-29T14:15:53")
                         )
                 )
         );
+    }
+
+    @Test
+    void shouldMapFailedToDto() {
+        GameWithFiles model = domainObjectFailed();
+
+        GameWithFilesHttpDto result = MAPPER.toDto(model);
+
+        var expectedResult = dtoFailed();
+        assertThat(result)
+                .usingRecursiveComparison().isEqualTo(expectedResult);
+    }
+
+    private GameWithFiles domainObjectFailed() {
+        Game game = TestGame.any();
+        return new GameWithFiles(
+                game,
+                singletonList(TestGameFile.failedBuilder()
+                        .gameId(game.getId())
+                        .build())
+        );
+    }
+
+    private GameWithFilesHttpDto dtoFailed() {
+        return dto(new FileBackupHttpDto(
+                FileBackupStatusHttpDto.FAILED,
+                "someFailedReason",
+                null
+        ));
     }
 
     @Test

--- a/backend/src/test/java/dev/codesoapbox/backity/core/gamefile/application/usecases/DeleteFileUseCaseTest.java
+++ b/backend/src/test/java/dev/codesoapbox/backity/core/gamefile/application/usecases/DeleteFileUseCaseTest.java
@@ -32,7 +32,7 @@ class DeleteFileUseCaseTest {
     @Test
     void shouldDeleteFileGivenGameFileStatusIsSuccess() {
         GameFile gameFile = mockSuccessfulGameFileExists();
-        String filePath = gameFile.getFileBackup().getFilePath();
+        String filePath = gameFile.getFileBackup().filePath();
 
         useCase.deleteFile(gameFile.getId());
 
@@ -52,7 +52,7 @@ class DeleteFileUseCaseTest {
 
         useCase.deleteFile(gameFile.getId());
 
-        assertThat(gameFile.getFileBackup().getStatus()).isEqualTo(FileBackupStatus.DISCOVERED);
+        assertThat(gameFile.getFileBackup().status()).isEqualTo(FileBackupStatus.DISCOVERED);
         verify(gameFileRepository).save(gameFile);
     }
 
@@ -65,7 +65,7 @@ class DeleteFileUseCaseTest {
         assertThatThrownBy(() -> useCase.deleteFile(gameFile.getId()))
                 .isSameAs(exception);
 
-        assertThat(gameFile.getFileBackup().getStatus()).isNotEqualTo(FileBackupStatus.DISCOVERED);
+        assertThat(gameFile.getFileBackup().status()).isNotEqualTo(FileBackupStatus.DISCOVERED);
         verify(gameFileRepository, never()).save(any());
     }
 

--- a/backend/src/test/java/dev/codesoapbox/backity/core/gamefile/application/usecases/DownloadFileUseCaseTest.java
+++ b/backend/src/test/java/dev/codesoapbox/backity/core/gamefile/application/usecases/DownloadFileUseCaseTest.java
@@ -46,7 +46,7 @@ class DownloadFileUseCaseTest {
 
     private FileResource mockFileResourceExists(GameFile gameFile) throws FileNotFoundException {
         FileResource fileResource = new FileResource(mock(InputStream.class), 5120L, "test_file.exe");
-        when(storageSolution.getFileResource(gameFile.getFileBackup().getFilePath()))
+        when(storageSolution.getFileResource(gameFile.getFileBackup().filePath()))
                 .thenReturn(fileResource);
 
         return fileResource;

--- a/backend/src/test/java/dev/codesoapbox/backity/core/gamefile/application/usecases/EnqueueFileUseCaseTest.java
+++ b/backend/src/test/java/dev/codesoapbox/backity/core/gamefile/application/usecases/EnqueueFileUseCaseTest.java
@@ -30,7 +30,7 @@ class EnqueueFileUseCaseTest {
 
         useCase.enqueue(gameFile.getId());
 
-        assertThat(gameFile.getFileBackup().getStatus()).isEqualTo(FileBackupStatus.ENQUEUED);
+        assertThat(gameFile.getFileBackup().status()).isEqualTo(FileBackupStatus.ENQUEUED);
         verify(gameFileRepository).save(gameFile);
     }
 

--- a/backend/src/test/java/dev/codesoapbox/backity/core/gamefile/domain/FileBackupTest.java
+++ b/backend/src/test/java/dev/codesoapbox/backity/core/gamefile/domain/FileBackupTest.java
@@ -1,0 +1,217 @@
+package dev.codesoapbox.backity.core.gamefile.domain;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class FileBackupTest {
+
+    @Nested
+    class Creation {
+
+        @Test
+        void shouldCreate() {
+            var result = new FileBackup(FileBackupStatus.DISCOVERED, null, null);
+
+            assertThat(result).isNotNull();
+        }
+
+        @SuppressWarnings("DataFlowIssue")
+        @Test
+        void constructorShouldThrowGivenNullStatus() {
+            assertThatThrownBy(() -> new FileBackup(
+                    null,
+                    null,
+                    null
+            )).isInstanceOf(NullPointerException.class)
+                    .hasMessage("status is marked non-null but is null");
+        }
+
+        @Test
+        void constructorShouldThrowGivenFailedWithoutReason() {
+            assertThatThrownBy(() -> new FileBackup(
+                    FileBackupStatus.FAILED,
+                    null,
+                    null
+            )).isInstanceOf(IllegalArgumentException.class)
+                    .hasMessage("failedReason is required");
+        }
+
+        @Test
+        void constructorShouldThrowGivenSuccessfulWithoutFilePath() {
+            assertThatThrownBy(() -> new FileBackup(
+                    FileBackupStatus.SUCCESS,
+                    null,
+                    null
+            )).isInstanceOf(IllegalArgumentException.class)
+                    .hasMessage("filePath is required");
+        }
+
+        @Test
+        void constructorShouldThrowGivenFailedReasonButNotFailed() {
+            assertThatThrownBy(() -> new FileBackup(
+                    FileBackupStatus.DISCOVERED,
+                    "someFailedReason",
+                    null
+            )).isInstanceOf(IllegalArgumentException.class)
+                    .hasMessage("failedReason must be null for this status");
+        }
+    }
+
+    @Nested
+    class Transitions {
+        @Test
+        void toDiscoveredShouldReturnNewInstanceWithoutFailedReason() {
+            var fileBackup = new FileBackup(
+                    FileBackupStatus.FAILED,
+                    "someFailedReason",
+                    null
+            );
+
+            FileBackup result = fileBackup.toDiscovered();
+
+            var expectedResult = new FileBackup(
+                    FileBackupStatus.DISCOVERED,
+                    null,
+                    null
+            );
+            assertThat(result).usingRecursiveComparison()
+                    .isEqualTo(expectedResult);
+        }
+
+        @Test
+        void toDiscoveredShouldReturnNewInstanceWithFilePath() {
+            var fileBackup = new FileBackup(
+                    FileBackupStatus.SUCCESS,
+                    null,
+                    "someFilePath"
+            );
+
+            FileBackup result = fileBackup.toDiscovered();
+
+            var expectedResult = new FileBackup(
+                    FileBackupStatus.DISCOVERED,
+                    null,
+                    "someFilePath"
+            );
+            assertThat(result).usingRecursiveComparison()
+                    .isEqualTo(expectedResult);
+        }
+
+        @Test
+        void toEnqueuedShouldReturnNewInstanceWithoutFailedReason() {
+            var fileBackup = new FileBackup(
+                    FileBackupStatus.FAILED,
+                    "someFailedReason",
+                    null
+            );
+
+            FileBackup result = fileBackup.toEnqueued();
+
+            var expectedResult = new FileBackup(
+                    FileBackupStatus.ENQUEUED,
+                    null,
+                    null
+            );
+            assertThat(result).usingRecursiveComparison()
+                    .isEqualTo(expectedResult);
+        }
+
+        @Test
+        void toEnqueuedShouldReturnNewInstanceWithFilePath() {
+            var fileBackup = new FileBackup(
+                    FileBackupStatus.SUCCESS,
+                    null,
+                    "someFilePath"
+            );
+
+            FileBackup result = fileBackup.toEnqueued();
+
+            var expectedResult = new FileBackup(
+                    FileBackupStatus.ENQUEUED,
+                    null,
+                    "someFilePath"
+            );
+            assertThat(result).usingRecursiveComparison()
+                    .isEqualTo(expectedResult);
+        }
+
+        @Test
+        void toInProgressShouldReturnNewInstanceWithoutFailedReason() {
+            var fileBackup = new FileBackup(
+                    FileBackupStatus.FAILED,
+                    "someFailedReason",
+                    null
+            );
+
+            FileBackup result = fileBackup.toInProgress();
+
+            var expectedResult = new FileBackup(
+                    FileBackupStatus.IN_PROGRESS,
+                    null,
+                    null
+            );
+            assertThat(result).usingRecursiveComparison()
+                    .isEqualTo(expectedResult);
+        }
+
+        @Test
+        void toInProgressShouldReturnNewInstanceWithFilePath() {
+            var fileBackup = new FileBackup(
+                    FileBackupStatus.SUCCESS,
+                    null,
+                    "someFilePath"
+            );
+
+            FileBackup result = fileBackup.toInProgress();
+
+            var expectedResult = new FileBackup(
+                    FileBackupStatus.IN_PROGRESS,
+                    null,
+                    "someFilePath"
+            );
+            assertThat(result).usingRecursiveComparison()
+                    .isEqualTo(expectedResult);
+        }
+
+        @Test
+        void toSuccessfulShouldReturnNewInstanceWithoutFailedReason() {
+            var fileBackup = new FileBackup(
+                    FileBackupStatus.FAILED,
+                    "someFailedReason",
+                    null
+            );
+
+            FileBackup result = fileBackup.toSuccessful("someFilePath");
+
+            var expectedResult = new FileBackup(
+                    FileBackupStatus.SUCCESS,
+                    null,
+                    "someFilePath"
+            );
+            assertThat(result).usingRecursiveComparison()
+                    .isEqualTo(expectedResult);
+        }
+
+        @Test
+        void toFailedShouldReturnNewInstanceWithFilePath() {
+            var fileBackup = new FileBackup(
+                    FileBackupStatus.SUCCESS,
+                    null,
+                    "someFilePath"
+            );
+
+            FileBackup result = fileBackup.toFailed("someFailedReason");
+
+            var expectedResult = new FileBackup(
+                    FileBackupStatus.FAILED,
+                    "someFailedReason",
+                    "someFilePath"
+            );
+            assertThat(result).usingRecursiveComparison()
+                    .isEqualTo(expectedResult);
+        }
+    }
+}

--- a/backend/src/test/java/dev/codesoapbox/backity/core/gamefile/domain/GameFileTest.java
+++ b/backend/src/test/java/dev/codesoapbox/backity/core/gamefile/domain/GameFileTest.java
@@ -34,12 +34,21 @@ class GameFileTest {
     }
 
     @Test
+    void shouldMarkAsDiscovered() {
+        GameFile gameFile = TestGameFile.discovered();
+
+        gameFile.markAsDiscovered();
+
+        assertThat(gameFile.getFileBackup().status()).isEqualTo(FileBackupStatus.DISCOVERED);
+    }
+
+    @Test
     void shouldMarkAsEnqueued() {
         GameFile gameFile = TestGameFile.discovered();
 
         gameFile.markAsEnqueued();
 
-        assertThat(gameFile.getFileBackup().getStatus()).isEqualTo(FileBackupStatus.ENQUEUED);
+        assertThat(gameFile.getFileBackup().status()).isEqualTo(FileBackupStatus.ENQUEUED);
     }
 
     @Test
@@ -50,8 +59,8 @@ class GameFileTest {
 
         gameFile.markAsFailed(failedReason);
 
-        assertThat(gameFile.getFileBackup().getFailedReason()).isEqualTo(failedReason);
-        assertThat(gameFile.getFileBackup().getStatus()).isEqualTo(FileBackupStatus.FAILED);
+        assertThat(gameFile.getFileBackup().failedReason()).isEqualTo(failedReason);
+        assertThat(gameFile.getFileBackup().status()).isEqualTo(FileBackupStatus.FAILED);
         assertThat(gameFile.getDomainEvents()).containsExactly(expectedEvent);
     }
 
@@ -66,7 +75,7 @@ class GameFileTest {
 
         gameFile.markAsInProgress();
 
-        assertThat(gameFile.getFileBackup().getStatus()).isEqualTo(FileBackupStatus.IN_PROGRESS);
+        assertThat(gameFile.getFileBackup().status()).isEqualTo(FileBackupStatus.IN_PROGRESS);
         assertThat(gameFile.getDomainEvents()).containsExactly(expectedEvent);
     }
 
@@ -81,7 +90,7 @@ class GameFileTest {
                 fileSource.version(),
                 fileSource.originalFileName(),
                 fileSource.size(),
-                fileBackup.getFilePath()
+                fileBackup.filePath()
         );
     }
 
@@ -92,8 +101,8 @@ class GameFileTest {
 
         gameFile.markAsDownloaded("someFilePath");
 
-        assertThat(gameFile.getFileBackup().getFilePath()).isEqualTo("someFilePath");
-        assertThat(gameFile.getFileBackup().getStatus()).isEqualTo(FileBackupStatus.SUCCESS);
+        assertThat(gameFile.getFileBackup().filePath()).isEqualTo("someFilePath");
+        assertThat(gameFile.getFileBackup().status()).isEqualTo(FileBackupStatus.SUCCESS);
         assertThat(gameFile.getDomainEvents()).containsExactly(expectedEvent);
     }
 

--- a/backend/src/test/java/dev/codesoapbox/backity/core/gamefile/domain/TestGameFile.java
+++ b/backend/src/test/java/dev/codesoapbox/backity/core/gamefile/domain/TestGameFile.java
@@ -30,18 +30,6 @@ public final class TestGameFile {
     @lombok.Builder.Default
     private LocalDateTime dateModified = LocalDateTime.parse("2023-04-29T14:15:53");
 
-    public static GameFile full() {
-        return fullBuilder().build();
-    }
-
-    public static Builder fullBuilder() {
-        return discoveredBuilder()
-                .fileBackup(TestFileBackup.discoveredBuilder()
-                        .failedReason("someFailedReason")
-                        .filePath("someFilePath")
-                        .build());
-    }
-
     public static Builder discoveredBuilder() {
         return new Builder();
     }

--- a/backend/src/test/java/dev/codesoapbox/backity/core/gamefile/infrastructure/adapters/driven/persistence/jpa/GameFileJpaRepositoryAbstractIT.java
+++ b/backend/src/test/java/dev/codesoapbox/backity/core/gamefile/infrastructure/adapters/driven/persistence/jpa/GameFileJpaRepositoryAbstractIT.java
@@ -98,7 +98,7 @@ abstract class GameFileJpaRepositoryAbstractIT {
 
     @Test
     void shouldSave() {
-        GameFile newGameFile = TestGameFile.full();
+        GameFile newGameFile = TestGameFile.discovered();
 
         GameFile result = gameFileJpaRepository.save(newGameFile);
         entityManager.flush();
@@ -129,7 +129,7 @@ abstract class GameFileJpaRepositoryAbstractIT {
 
     @Test
     void saveShouldPublishEventsAfterCommitting() {
-        GameFile gameFile = TestGameFile.full();
+        GameFile gameFile = TestGameFile.discovered();
         gameFile.markAsInProgress();
         gameFileJpaRepository.save(gameFile);
 
@@ -140,7 +140,7 @@ abstract class GameFileJpaRepositoryAbstractIT {
 
     @Test
     void saveShouldClearEvents() {
-        GameFile gameFile = TestGameFile.full();
+        GameFile gameFile = TestGameFile.discovered();
         gameFile.markAsInProgress();
         gameFileJpaRepository.save(gameFile);
 

--- a/backend/src/test/java/dev/codesoapbox/backity/core/gamefile/infrastructure/adapters/driving/api/http/controllers/GetCurrentlyDownloadingFileControllerIT.java
+++ b/backend/src/test/java/dev/codesoapbox/backity/core/gamefile/infrastructure/adapters/driving/api/http/controllers/GetCurrentlyDownloadingFileControllerIT.java
@@ -30,7 +30,7 @@ class GetCurrentlyDownloadingFileControllerIT {
 
     @Test
     void shouldGetCurrentlyDownloadingFile() throws Exception {
-        GameFile gameFile = TestGameFile.full();
+        GameFile gameFile = TestGameFile.inProgress();
 
         when(useCase.findCurrentlyDownloadingFile())
                 .thenReturn(Optional.of(gameFile));
@@ -49,8 +49,8 @@ class GetCurrentlyDownloadingFileControllerIT {
                         "size": "5 KB"
                       },
                       "fileBackup": {
-                        "status": "DISCOVERED",
-                        "failedReason": "someFailedReason",
+                        "status": "IN_PROGRESS",
+                        "failedReason": null,
                         "filePath": "someFilePath"
                       },
                       "dateCreated": "2022-04-29T14:15:53",

--- a/backend/src/test/java/dev/codesoapbox/backity/gameproviders/gog/infrastructure/adapters/driven/api/embed/GogFileBackupServiceTest.java
+++ b/backend/src/test/java/dev/codesoapbox/backity/gameproviders/gog/infrastructure/adapters/driven/api/embed/GogFileBackupServiceTest.java
@@ -40,7 +40,7 @@ class GogFileBackupServiceTest {
 
         gogFileBackupService.backUpFile(gameFile, downloadProgress);
 
-        String filePath = gameFile.getFileBackup().getFilePath();
+        String filePath = gameFile.getFileBackup().filePath();
         verify(urlFileDownloader).downloadFile(trackableFileStream, gameFile, filePath);
     }
 

--- a/backend/src/test/java/dev/codesoapbox/backity/shared/infrastructure/adapters/driving/api/http/model/gamefile/GameFileHttpDtoMapperTest.java
+++ b/backend/src/test/java/dev/codesoapbox/backity/shared/infrastructure/adapters/driving/api/http/model/gamefile/GameFileHttpDtoMapperTest.java
@@ -14,8 +14,8 @@ class GameFileHttpDtoMapperTest {
     private static final GameFileHttpDtoMapper MAPPER = Mappers.getMapper(GameFileHttpDtoMapper.class);
 
     @Test
-    void shouldMapToDto() {
-        GameFile domain = TestGameFile.full();
+    void shouldMapSuccessfulToDto() {
+        GameFile domain = TestGameFile.successful();
 
         GameFileHttpDto result = MAPPER.toDto(domain);
 
@@ -32,9 +32,40 @@ class GameFileHttpDtoMapperTest {
                         "5 KB"
                 ),
                 new FileBackupHttpDto(
-                        FileBackupStatusHttpDto.DISCOVERED,
-                        "someFailedReason",
+                        FileBackupStatusHttpDto.SUCCESS,
+                        null,
                         "someFilePath"
+                ),
+                LocalDateTime.parse("2022-04-29T14:15:53"),
+                LocalDateTime.parse("2023-04-29T14:15:53")
+        );
+
+        assertThat(result)
+                .usingRecursiveComparison().isEqualTo(expectedResult);
+    }
+
+    @Test
+    void shouldMapFailedToDto() {
+        GameFile domain = TestGameFile.failed();
+
+        GameFileHttpDto result = MAPPER.toDto(domain);
+
+        var expectedResult = new GameFileHttpDto(
+                "acde26d7-33c7-42ee-be16-bca91a604b48",
+                "1eec1c19-25bf-4094-b926-84b5bb8fa281",
+                new FileSourceHttpDto(
+                        "GOG",
+                        "Game 1",
+                        "Game 1 (Installer)",
+                        "1.0.0",
+                        "/downlink/some_game/some_file",
+                        "game_1_installer.exe",
+                        "5 KB"
+                ),
+                new FileBackupHttpDto(
+                        FileBackupStatusHttpDto.FAILED,
+                        "someFailedReason",
+                        null
                 ),
                 LocalDateTime.parse("2022-04-29T14:15:53"),
                 LocalDateTime.parse("2023-04-29T14:15:53")


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Improved immutability and validation in file backup management, replacing mutable classes with immutable records and encapsulating state transitions.
  - Updated method and property access patterns throughout the application for consistency and clarity.
  - Consolidated import statements and refined internal mappings.

- **New Features**
  - Added the ability to mark a file as "discovered" in the file management workflow.

- **Bug Fixes**
  - Ensured a default error message is set when an exception message is missing during failure handling.

- **Tests**
  - Added comprehensive tests for file backup state transitions and validation.
  - Updated existing tests to align with new immutable and accessor patterns.
  - Enhanced test coverage for mapping of successful and failed file backups in API responses.
  - Expanded integration tests to cover multiple file backup statuses in API responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->