### PR TITLE
refactor(backend): Enforce config class package being inside `infrastructure` package

### DIFF
--- a/backend/src/main/java/dev/codesoapbox/backity/core/backuptarget/infrastructure/config/BackupTargetControllerBeanConfig.java
+++ b/backend/src/main/java/dev/codesoapbox/backity/core/backuptarget/infrastructure/config/BackupTargetControllerBeanConfig.java
@@ -1,4 +1,4 @@
-package dev.codesoapbox.backity.core.backuptarget.config;
+package dev.codesoapbox.backity.core.backuptarget.infrastructure.config;
 
 import dev.codesoapbox.backity.core.backuptarget.infrastructure.adapters.driving.api.http.model.BackupTargetHttpDtoMapper;
 import org.mapstruct.factory.Mappers;

--- a/backend/src/main/java/dev/codesoapbox/backity/core/backuptarget/infrastructure/config/BackupTargetHardCodedRepositoryBeanConfig.java
+++ b/backend/src/main/java/dev/codesoapbox/backity/core/backuptarget/infrastructure/config/BackupTargetHardCodedRepositoryBeanConfig.java
@@ -1,4 +1,4 @@
-package dev.codesoapbox.backity.core.backuptarget.config;
+package dev.codesoapbox.backity.core.backuptarget.infrastructure.config;
 
 import dev.codesoapbox.backity.core.backuptarget.adapters.driven.persistence.hardcoded.HardCodedBackupTargetRepository;
 import dev.codesoapbox.backity.core.backuptarget.domain.BackupTargetRepository;

--- a/backend/src/main/java/dev/codesoapbox/backity/core/backuptarget/infrastructure/config/BackupTargetUseCaseBeanConfig.java
+++ b/backend/src/main/java/dev/codesoapbox/backity/core/backuptarget/infrastructure/config/BackupTargetUseCaseBeanConfig.java
@@ -1,4 +1,4 @@
-package dev.codesoapbox.backity.core.backuptarget.config;
+package dev.codesoapbox.backity.core.backuptarget.infrastructure.config;
 
 import dev.codesoapbox.backity.core.backuptarget.application.GetBackupTargetsUseCase;
 import dev.codesoapbox.backity.core.backuptarget.domain.BackupTargetRepository;

--- a/backend/src/test/java/dev/codesoapbox/backity/archunit/rules/AdditionalArchitectureRules.java
+++ b/backend/src/test/java/dev/codesoapbox/backity/archunit/rules/AdditionalArchitectureRules.java
@@ -8,6 +8,7 @@ import com.tngtech.archunit.lang.ConditionEvents;
 import com.tngtech.archunit.lang.SimpleConditionEvent;
 import com.tngtech.archunit.lang.syntax.ArchRuleDefinition;
 import dev.codesoapbox.backity.BackityApplication;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.data.repository.Repository;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -36,7 +37,8 @@ public class AdditionalArchitectureRules {
     static final String SPRING_PACKAGE = "org.springframework..";
     static final String DOMAIN_PACKAGE = ".." + PortsAndAdaptersArchitectureRules.Constants.DOMAIN_PACKAGE
                                          + "..";
-    static final String CONFIG_PACKAGE = ".." + PortsAndAdaptersArchitectureRules.Constants.CONFIG_PACKAGE
+    static final String CONFIG_PACKAGE = "..infrastructure."
+                                         + PortsAndAdaptersArchitectureRules.Constants.CONFIG_PACKAGE
                                          + "..";
     static final String APPLICATION_PACKAGE = ".."
                                               + PortsAndAdaptersArchitectureRules.Constants.APPLICATION_PACKAGE + "..";
@@ -69,6 +71,29 @@ public class AdditionalArchitectureRules {
                     Negative consequences:
                     - May introduce additional complexity in small modules, \
                     as each feature package may need its own exception subpackage.
+                    """);
+
+    @ArchTest
+    static final ArchRule CONFIGURATION_SHOULD_RESIDE_IN_CORRECT_PACKAGE = classes().that()
+            .areAnnotatedWith(Configuration.class)
+            .should().resideInAPackage(CONFIG_PACKAGE)
+            .because("""
+                    a consistent structure makes code easier to work with.
+                    
+                    Context:
+                    If configuration classes are scattered across the project, developers \
+                    may struggle to find and use them properly. This can lead to duplicated and messy code.
+                    Keeping them in a dedicated package makes it easier to manage and understand them.
+                    
+                    Positive consequences:
+                    - Makes configuration classes easier to locate and manage.
+                    - Reduces confusion by maintaining a consistent project structure.
+                    
+                    Neutral consequences:
+                    - Configuration classes will still be spread across feature packages.
+                    
+                    Negative consequences:
+                    - Can introduce unnecessary subpackage complexity in simple modules.
                     """);
 
     @ArchTest

--- a/backend/src/test/java/dev/codesoapbox/backity/testing/http/annotations/ConfigureSharedControllerTestBeans.java
+++ b/backend/src/test/java/dev/codesoapbox/backity/testing/http/annotations/ConfigureSharedControllerTestBeans.java
@@ -1,7 +1,7 @@
 package dev.codesoapbox.backity.testing.http.annotations;
 
 import dev.codesoapbox.backity.core.backuptarget.application.GetBackupTargetsUseCase;
-import dev.codesoapbox.backity.core.backuptarget.config.BackupTargetControllerBeanConfig;
+import dev.codesoapbox.backity.core.backuptarget.infrastructure.config.BackupTargetControllerBeanConfig;
 import dev.codesoapbox.backity.core.discovery.application.GameContentDiscoveryService;
 import dev.codesoapbox.backity.core.discovery.application.usecases.GetGameContentDiscoveryOverviewsUseCase;
 import dev.codesoapbox.backity.core.discovery.application.usecases.StartGameContentDiscoveryUseCase;

--- a/docs/index.md
+++ b/docs/index.md
@@ -51,9 +51,9 @@ See [Profiles overview](#profiles-overview) for more mock dependencies.
 
 ## Running the application
 
-1. Build the project:
+1. Build the project:\
    `./mvnw clean package`
-2. Start the backend:
+2. Start the backend:\
    `./mvnw spring-boot:run -Dspring-boot.run.profiles=dev,dev-provider-api`
 3. Access the application at [http://localhost:8080](http://localhost:8080).
 


### PR DESCRIPTION
refactor(backend): Enforce config class package being inside `infrastructure` package

docs: Add newlines in "getting started" numbered list

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved formatting in the instructions for running the application to enhance readability.

* **Tests**
  * Updated test rules to enforce consistent placement of configuration classes.
  * Adjusted imports in test files to reflect updated package structure.

* **Refactor**
  * Moved configuration classes to a more specific package for better organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->