### PR TITLE
ci: Cache Playwright browser binaries

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,6 +76,24 @@ jobs:
         working-directory: docker/e2e
         run: ./start-containers-safely.sh
 
+      - name: Resolve Playwright version
+        id: playwright-version
+        working-directory: e2e
+        run: |
+          RAW=$(mvn -q -Dexec.mainClass=com.microsoft.playwright.CLI -Dexec.args="--version" -Dexec.classpathScope=test exec:java)
+          VER=$(echo "$RAW" | grep -Eo '[0-9]+\.[0-9]+\.[0-9]+' | head -n1)
+          echo "version=$VER" >> "$GITHUB_OUTPUT"
+
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          # Key ties the cache to OS + Playwright version changes (via e2e/pom.xml)
+          key: ${{ runner.os }}-playwright-${{ steps.playwright-version.outputs.version }}
+          restore-keys: |
+            ${{ runner.os }}-playwright-
+
       - name: Configure Playwright
         working-directory: e2e
         run: sudo mvn exec:java -e -D exec.mainClass=com.microsoft.playwright.CLI -D exec.args="install-deps"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Tests
  - Optimized end-to-end testing workflow by resolving the Playwright version and caching browsers, reducing download time and improving test stability. No user-facing changes.
- Chores
  - Enhanced CI performance by introducing version-aware caching for Playwright assets, leading to faster, more consistent builds across runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->