### PR TITLE
ci(e2e): Save Playwright traces to `e2e/target/playwright-traces` so they get removed on `mvn clean`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -110,7 +110,7 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: playwright-traces
-          path: e2e/traces/**/*.zip
+          path: e2e/target/playwright-traces/**/*.zip
           retention-days: 30
 
       - name: Show Playwright trace link

--- a/docs/dev/getting-started/advanced-topics.md
+++ b/docs/dev/getting-started/advanced-topics.md
@@ -121,13 +121,14 @@ which will fail the build if the mutation threshold is below a certain value.
 
 ## Playwright trace files
 
-Playwright tests are configured to save trace files to `e2e/traces`.
+Playwright tests are configured to save trace files to `e2e/target/playwright-traces`.
 They are also uploaded as CI artifacts when the E2E test step fails. 
 You can open a trace file with the following command:
 
 ```shell
 # From the /e2e directory:
-mvn exec:java -e -D exec.mainClass=com.microsoft.playwright.CLI -Dexec.args="show-trace traces/trace_file_name.zip"
+mvn exec:java -e -D exec.mainClass=com.microsoft.playwright.CLI \
+-Dexec.args="show-trace target/playwright-traces/trace_file_name.zip"
 ```
 
 Alternatively, you can open the trace viewer and select the trace file manually:

--- a/e2e/.gitignore
+++ b/e2e/.gitignore
@@ -27,4 +27,3 @@
 ### Custom ###
 /games/
 /app.log
-/traces

--- a/e2e/src/test/java/dev/codesoapbox/backity/e2e/CustomOptions.java
+++ b/e2e/src/test/java/dev/codesoapbox/backity/e2e/CustomOptions.java
@@ -17,6 +17,6 @@ public class CustomOptions implements OptionsFactory {
                 .setContextOptions(new Browser.NewContextOptions()
                         .setBaseURL("http://localhost:8080"))
                 .setTrace(Options.Trace.RETAIN_ON_FAILURE)
-                .setOutputDir(Paths.get("traces"));
+                .setOutputDir(Paths.get("target/playwright-traces"));
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reorganized build and test artifact collection paths and configuration to improve development workflow organization and system maintainability.

* **Documentation**
  * Updated developer documentation to reflect new artifact storage locations with current setup instructions and examples for running end-to-end tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->