### PR TITLE
test(e2e): Refactor E2E tests to not expose Locators from Page Objects

### DIFF
--- a/docs/dev/adrs/project/project-0004-adhere-to-test-pyramid.md
+++ b/docs/dev/adrs/project/project-0004-adhere-to-test-pyramid.md
@@ -1,0 +1,79 @@
+---
+title: Adhere to the test pyramid
+status: accepted
+scope: project
+tags: ['testing']
+---
+
+## Context
+
+Many projects gravitate towards a testing strategy consisting primarily of E2E and integration tests, 
+the so-called Test Ice Cream Cone.
+These tests exercise real system behavior and require less knowledge of the codebase internals.
+
+However, this leads to tests which are:
+- slow (due to having to exercise the entire application),
+- complicated to set up (due to having little control over the SUT's dependencies and limited access to its API),
+- hard to understand (due to complex test code and hard-to-define SUT),
+- very brittle (any change in the system might break them, and depending on shared state makes flakiness more likely).
+
+Additionally, this exclusively outside-in view of testing makes it hard to focus on possible edge cases,
+and even harder to properly test them. In cases of defensive programming, it might often be impossible to bring
+the entire system to a state we want to test.
+
+Such an approach eventually leads to a point where refactoring becomes risky, as:
+
+- the expected behavior of each class is not properly documented as unit tests
+  (making it harder to understand the expected behavior),
+- it is not immediately obvious where each class is tested (or if it's tested at all), with tests being
+  scattered across several E2E/integration test classes (making us less confident in our refactoring),
+- tests for specific classes are likely to be duplicated across several E2E/integration tests
+  (increasing the work needed to update tests),
+- even a small change will require running the slow suite of E2E/integration tests (causing a slower feedback loop).
+
+Risky refactoring and the bugs that might come up due to the lack of a robust testing strategy may eventually lead to
+increased delivery times for new features.
+
+On the other hand, adhering to the test pyramid makes it so that we write more unit tests, which:
+
+- are much faster and can be run in parallel (making the feedback loop significantly faster),
+- fail due to much more localized issues (making it much easier to diagnose the problem and making them less brittle)
+- do not rely on shared state (making them less likely to be flaky)
+- have fewer moving parts and give us more control over them (making them much easier to set up)
+- force better modularity and separation of concerns (leading to cleaner architecture)
+
+At integration points, where unit tests are not practical, focused integration slice tests can provide the verification
+needed to validate edge cases in isolation from irrelevant parts of the system.
+
+Writing a small number of happy-path E2E tests can help verify that entire user journeys are working correctly,
+providing increased confidence in the application.
+
+## Decision
+
+- Write unit tests whenever possible.
+    - Do not share any state between unit tests.
+- Write integration tests at integration points (e.g., controllers, repositories, listeners, publishers).
+    - Write them as slice tests (don't initialize more of the application context than you need)
+        - Mock those parts of the system which are irrelevant to the test
+          (e.g., we don't need real use cases when testing a controller response)
+    - For controller tests, make sure to test the API contract
+      (e.g., assert on the full JSON response, HTTP code, etc.).
+    - For repository tests, make sure to test all edge cases. Assume the repository works correctly in all other tests.
+- Write a tiny amount of happy-path E2E for the most critical functionality.
+- Exclude E2E tests from code coverage metrics.
+
+## Consequences
+
+### Positive
+
+- Fast feedback loop due to focusing on lightweight unit tests which can run in parallel.
+- Improved reliability due to smaller, more focused tests being less flaky and easier to debug.
+- Less test duplication and overlap due to tests living close to their tested code.
+- Easier testing of edge cases due to easier access to SUT API and more control over dependencies.
+- Safer refactoring due to fast tests acting as easy-to-find documentation.
+- Increased long-term speed of delivery due to all of the above.
+
+### Negative
+
+- Increased upfront effort due to writing and maintaining more unit and slice tests
+- Contributors accustomed to writing E2E tests may find it hard to adjust to writing unit or integration tests.

--- a/e2e/src/test/java/dev/codesoapbox/backity/e2e/BackityTest.java
+++ b/e2e/src/test/java/dev/codesoapbox/backity/e2e/BackityTest.java
@@ -1,9 +1,7 @@
 package dev.codesoapbox.backity.e2e;
 
 import com.microsoft.playwright.Download;
-import com.microsoft.playwright.Locator;
 import com.microsoft.playwright.Page;
-import com.microsoft.playwright.assertions.LocatorAssertions;
 import com.microsoft.playwright.junit.UsePlaywright;
 import dev.codesoapbox.backity.e2e.backend.BackupTargetsApi;
 import dev.codesoapbox.backity.e2e.backend.FileCopiesApi;
@@ -23,8 +21,8 @@ import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.util.stream.Collectors;
 
-import static com.microsoft.playwright.assertions.PlaywrightAssertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @UsePlaywright(CustomOptions.class)
 class BackityTest {
@@ -33,9 +31,6 @@ class BackityTest {
     private static final String FILE_TO_DOWNLOAD_NAME = "test_game_1_installer_1.exe";
     private static final String FILE_TO_DOWNLOAD_EXPECTED_CONTENTS = "Source file contents";
     private static final String LOCAL_FOLDER_BACKUP_TARGET_NAME = "Local folder";
-
-    // The file backup scheduler runs once every N seconds; We must make sure to not fail the test before then.
-    private static final long EXPECTED_FILE_BACKUP_SCHEDULER_DELAY = 60_000L;
 
     private GameProvidersPage gameProvidersPage;
     private GamesPage gamesPage;
@@ -56,17 +51,10 @@ class BackityTest {
     }
 
     private void tryToLogOutOfGog() {
-        gameProvidersPage.navigate();
+        gameProvidersPage.visit();
         if (gameProvidersPage.isGogAuthenticated()) {
             gameProvidersPage.logOutFromGog();
         }
-        assertIsNotAuthenticated();
-    }
-
-    private void assertIsNotAuthenticated() {
-        assertThat(gameProvidersPage.getAuthenticationStatusLocator())
-                .containsText(GameProvidersPage.NOT_AUTHENTICATED_LOWERCASE,
-                        new LocatorAssertions.ContainsTextOptions().setIgnoreCase(true));
     }
 
     private void deleteAllFileBackups() {
@@ -75,7 +63,7 @@ class BackityTest {
     }
 
     private void deleteAllBackupTargets() {
-        settingsPage.navigate();
+        settingsPage.visit();
         settingsPage.deleteAllBackupTargets();
     }
 
@@ -86,27 +74,39 @@ class BackityTest {
 
     @Test
     void shouldBackupGogFiles() {
-        settingsPage.navigate();
+        settingsPage.visit();
         settingsPage.createBackupTarget(LOCAL_FOLDER_BACKUP_TARGET_NAME);
 
-        gameProvidersPage.navigate();
-
+        gameProvidersPage.visit();
         gameProvidersPage.authenticateGog();
-        assertIsAuthenticated();
-
         gameProvidersPage.discoverAllFiles();
 
         gamesPage.visit();
         gamesPage.backUpFile(FILE_TO_DOWNLOAD_TITLE, LOCAL_FOLDER_BACKUP_TARGET_NAME);
-        assertThatFileWasBackedUp(FILE_TO_DOWNLOAD_TITLE, LOCAL_FOLDER_BACKUP_TARGET_NAME);
+
+        assertFileCopyIsBackedUp();
         Download download = gamesPage.startFileDownload(FILE_TO_DOWNLOAD_TITLE, LOCAL_FOLDER_BACKUP_TARGET_NAME);
         try {
-            assertEquals(FILE_TO_DOWNLOAD_NAME, download.suggestedFilename());
+            assertFileNameIsCorrect(download);
             String fileContent = downloadFileAndReadContent(download);
-            assertEquals(FILE_TO_DOWNLOAD_EXPECTED_CONTENTS, fileContent);
+            assertFileContentIsCorrect(fileContent);
         } finally {
             download.delete();
         }
+    }
+
+    private void assertFileCopyIsBackedUp() {
+        assertTrue(
+                gamesPage.fileCopyStatusIsStoredIntegrityUnknown(
+                        FILE_TO_DOWNLOAD_TITLE, LOCAL_FOLDER_BACKUP_TARGET_NAME),
+                () -> "Expected File Copy status to be Stored Integrity Unknown, but was: "
+                        + gamesPage.getFileCopyStatusText(FILE_TO_DOWNLOAD_TITLE, LOCAL_FOLDER_BACKUP_TARGET_NAME));
+    }
+
+    private void assertFileNameIsCorrect(Download download) {
+        assertEquals(FILE_TO_DOWNLOAD_NAME, download.suggestedFilename(),
+                () -> "Expected file name to be " + FILE_TO_DOWNLOAD_NAME
+                        + ", but was " + download.suggestedFilename());
     }
 
     @SneakyThrows
@@ -115,22 +115,14 @@ class BackityTest {
                 InputStream inputStream = download.createReadStream();
                 var reader = new BufferedReader(new InputStreamReader(inputStream, StandardCharsets.UTF_8))
         ) {
-            return reader.lines().collect(Collectors.joining("\n"));
+            return reader.lines()
+                    .collect(Collectors.joining("\n"));
         }
     }
 
-    private void assertIsAuthenticated() {
-        assertThat(gameProvidersPage.getAuthenticationStatusLocator())
-                .not().containsText(GameProvidersPage.NOT_AUTHENTICATED_LOWERCASE,
-                        new LocatorAssertions.ContainsTextOptions().setIgnoreCase(true));
-    }
-
-    @SuppressWarnings("SameParameterValue")
-    private void assertThatFileWasBackedUp(String fileTitle, String backupTargetName) {
-        Locator processedFileStatus = gamesPage.getFileCopyStatus(fileTitle, backupTargetName);
-        assertThat(processedFileStatus).isVisible();
-        assertThat(processedFileStatus).containsText("STORED_INTEGRITY_UNKNOWN",
-                new LocatorAssertions.ContainsTextOptions()
-                        .setTimeout(EXPECTED_FILE_BACKUP_SCHEDULER_DELAY + 5000L));
+    private void assertFileContentIsCorrect(String fileContent) {
+        assertEquals(FILE_TO_DOWNLOAD_EXPECTED_CONTENTS, fileContent,
+                () -> "Expected file content to be " + FILE_TO_DOWNLOAD_EXPECTED_CONTENTS
+                        + ", but was " + fileContent);
     }
 }

--- a/e2e/src/test/java/dev/codesoapbox/backity/e2e/CustomOptions.java
+++ b/e2e/src/test/java/dev/codesoapbox/backity/e2e/CustomOptions.java
@@ -12,7 +12,7 @@ public class CustomOptions implements OptionsFactory {
 
     @Override
     public Options getOptions() {
-        boolean isHeadless = Boolean.parseBoolean(System.getProperty("headless", "false"));
+        boolean isHeadless = Boolean.parseBoolean(System.getProperty("headless", "true"));
 
         return new Options()
                 .setHeadless(isHeadless)

--- a/e2e/src/test/java/dev/codesoapbox/backity/e2e/backend/BackendApiAssertion.java
+++ b/e2e/src/test/java/dev/codesoapbox/backity/e2e/backend/BackendApiAssertion.java
@@ -2,6 +2,8 @@ package dev.codesoapbox.backity.e2e.backend;
 
 import com.microsoft.playwright.Response;
 import dev.codesoapbox.backity.e2e.CustomOptions;
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -15,6 +17,7 @@ public class BackendApiAssertion {
         return new Dsl(prefixedUrl, response).new Method();
     }
 
+    @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
     public static class Dsl {
 
         private static final String URL_PREFIX = CustomOptions.BASE_URL + "/api";
@@ -22,11 +25,6 @@ public class BackendApiAssertion {
         private final String url;
         private final Response response;
         private final List<Supplier<Boolean>> assertions = new ArrayList<>();
-
-        private Dsl(String url, Response response) {
-            this.url = url;
-            this.response = response;
-        }
 
         public class Method {
 

--- a/e2e/src/test/java/dev/codesoapbox/backity/e2e/pages/GameProvidersPage.java
+++ b/e2e/src/test/java/dev/codesoapbox/backity/e2e/pages/GameProvidersPage.java
@@ -4,13 +4,12 @@ import com.microsoft.playwright.Locator;
 import com.microsoft.playwright.Page;
 import com.microsoft.playwright.assertions.LocatorAssertions;
 import com.microsoft.playwright.options.WaitForSelectorState;
-import lombok.Getter;
 
 import static com.microsoft.playwright.assertions.PlaywrightAssertions.assertThat;
 
 public class GameProvidersPage {
 
-    public static final String NOT_AUTHENTICATED_LOWERCASE = "not authenticated";
+    private static final String NOT_AUTHENTICATED_LOWERCASE = "not authenticated";
 
     private final Page page;
     private final Locator logInToGogBtn;
@@ -22,9 +21,6 @@ public class GameProvidersPage {
     private final Locator startDiscoveryBtn;
     private final Locator lastDiscoveryTimestamp;
 
-    @Getter
-    private final Locator discoveredFilesTable;
-
     public GameProvidersPage(Page page) {
         this.page = page;
         logInToGogBtn = page.getByTestId("log-in-to-gog-btn");
@@ -35,10 +31,9 @@ public class GameProvidersPage {
         gogLogOutButton = page.getByTestId("log-out-gog-btn");
         startDiscoveryBtn = page.getByTestId("start-game-content-discovery-btn");
         lastDiscoveryTimestamp = page.getByTestId("last-discovery-timestamp");
-        discoveredFilesTable = page.getByTestId("discovered-file-copies-table");
     }
 
-    public void navigate() {
+    public void visit() {
         page.navigate("/");
     }
 
@@ -51,6 +46,12 @@ public class GameProvidersPage {
         gogLoginPopup.close();
 
         gogModalAuthenticateButton.click();
+
+        page.waitForCondition(() ->
+                !gogAuthStatus.textContent()
+                        .toLowerCase()
+                        .contains(NOT_AUTHENTICATED_LOWERCASE)
+        );
     }
 
     private GogLoginPopup summonGogLoginForm() {
@@ -60,10 +61,6 @@ public class GameProvidersPage {
         return new GogLoginPopup(loginPopup);
     }
 
-    public Locator getAuthenticationStatusLocator() {
-        return gogAuthStatus;
-    }
-
     public boolean isGogAuthenticated() {
         gogAuthStatus.waitFor(new Locator.WaitForOptions().setState(WaitForSelectorState.VISIBLE));
         return !gogAuthStatus.textContent().toLowerCase().contains(NOT_AUTHENTICATED_LOWERCASE);
@@ -71,6 +68,11 @@ public class GameProvidersPage {
 
     public void logOutFromGog() {
         gogLogOutButton.click();
+        page.waitForCondition(() ->
+                gogAuthStatus.textContent()
+                        .toLowerCase()
+                        .contains(NOT_AUTHENTICATED_LOWERCASE)
+        );
     }
 
     public void discoverAllFiles() {

--- a/e2e/src/test/java/dev/codesoapbox/backity/e2e/pages/GamesPage.java
+++ b/e2e/src/test/java/dev/codesoapbox/backity/e2e/pages/GamesPage.java
@@ -9,7 +9,12 @@ import dev.codesoapbox.backity.e2e.backend.FileCopiesApi;
 import dev.codesoapbox.backity.e2e.backend.FileCopyQueueApi;
 import dev.codesoapbox.backity.e2e.backend.GamesApi;
 
+import java.util.Set;
+
 public class GamesPage {
+
+    // The file backup scheduler runs once every N seconds; We must make sure to not fail the test before then.
+    private static final long EXPECTED_FILE_BACKUP_SCHEDULER_DELAY = 60_000L;
 
     private static final Locator.ClickOptions SHORT_TIMEOUT_CLICK = new Locator.ClickOptions().setTimeout(2000);
 
@@ -19,6 +24,13 @@ public class GamesPage {
     private static final String SOURCE_FILE_TEST_ID = "game-file-item";
     private static final String FILE_COPY_ITEM_TEST_ID = "file-copy-item";
     private static final String FILE_COPY_STATUS_TEST_ID = "file-copy-status";
+
+    private static final String STORED_INTEGRITY_UNKNOWN_STATUS = "STORED_INTEGRITY_UNKNOWN";
+    private static final Set<String> TERMINAL_STATUSES = Set.of(
+            STORED_INTEGRITY_UNKNOWN_STATUS,
+            "STORED_INTEGRITY_VERIFIED",
+            "FAILED"
+    );
 
     private final Page page;
     private final GamesApi gamesApi;
@@ -100,8 +112,21 @@ public class GamesPage {
     }
 
     public void backUpFile(String fileTitle, String backupTargetName) {
+        startFileBackup(fileTitle, backupTargetName);
+        waitForFileBackupToFinish(fileTitle, backupTargetName);
+    }
+
+    private void startFileBackup(String fileTitle, String backupTargetName) {
         Locator fileCopyBackupBtn = getFileCopyBackupButton(fileTitle, backupTargetName);
         page.waitForResponse(fileCopyQueueApi::isEnqueued, fileCopyBackupBtn::click);
+    }
+
+    private void waitForFileBackupToFinish(String fileTitle, String backupTargetName) {
+        Locator statusLocator = getFileCopyStatus(fileTitle, backupTargetName);
+        page.waitForCondition(
+                () -> TERMINAL_STATUSES.contains(statusLocator.textContent().strip().toUpperCase()),
+                new Page.WaitForConditionOptions().setTimeout(EXPECTED_FILE_BACKUP_SCHEDULER_DELAY + 3000L)
+        );
     }
 
     private Locator getFileCopyBackupButton(String fileTitle, String backupTargetName) {
@@ -117,9 +142,17 @@ public class GamesPage {
                 .filter(new Locator.FilterOptions().setHasText(backupTargetName));
     }
 
-    public Locator getFileCopyStatus(String fileTitle, String backupTargetName) {
+    private Locator getFileCopyStatus(String fileTitle, String backupTargetName) {
         return getFileCopyItem(fileTitle, backupTargetName)
                 .getByTestId(FILE_COPY_STATUS_TEST_ID);
+    }
+
+    public boolean fileCopyStatusIsStoredIntegrityUnknown(String fileTitle, String backupTargetName) {
+        return getFileCopyStatusText(fileTitle, backupTargetName).contains(STORED_INTEGRITY_UNKNOWN_STATUS);
+    }
+
+    public String getFileCopyStatusText(String fileTitle, String backupTargetName) {
+        return getFileCopyStatus(fileTitle, backupTargetName).textContent().strip();
     }
 
     public Download startFileDownload(String fileTitle, String backupTargetName) {

--- a/e2e/src/test/java/dev/codesoapbox/backity/e2e/pages/SettingsPage.java
+++ b/e2e/src/test/java/dev/codesoapbox/backity/e2e/pages/SettingsPage.java
@@ -28,7 +28,7 @@ public class SettingsPage {
         this.loader = page.getByTestId("loader");
     }
 
-    public void navigate() {
+    public void visit() {
         page.navigate("/settings");
         waitUntilLoaderDisappears();
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Reworked E2E flows for authentication and backup checks, replacing fragile UI-locator assertions with direct assertions and helperized checks to improve reliability.
  * Enhanced backup verification to wait for terminal status before asserting outcomes.

* **Documentation**
  * Added an ADR outlining adherence to the test pyramid and recommended testing scope.

* **Chores**
  * Updated test utilities and default browser headless behavior for consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->