### PR TITLE
test: Add ArchUnit test naming rules

### DIFF
--- a/backend/src/test/java/dev/codesoapbox/backity/BackityApplicationIT.java
+++ b/backend/src/test/java/dev/codesoapbox/backity/BackityApplicationIT.java
@@ -10,7 +10,7 @@ class BackityApplicationIT {
 
     @SuppressWarnings("squid:S2699")
     @Test
-    void contextLoads() {
+    void shouldLoadContext() {
         // Intentionally empty - we're only testing that the application starts up
     }
 }

--- a/backend/src/test/java/dev/codesoapbox/backity/archunit/rules/TestRules.java
+++ b/backend/src/test/java/dev/codesoapbox/backity/archunit/rules/TestRules.java
@@ -2,19 +2,30 @@ package dev.codesoapbox.backity.archunit.rules;
 
 import com.tngtech.archunit.core.domain.JavaClass;
 import com.tngtech.archunit.core.domain.JavaClasses;
+import com.tngtech.archunit.core.domain.JavaMethod;
+import com.tngtech.archunit.core.importer.ClassFileImporter;
+import com.tngtech.archunit.core.importer.ImportOption;
 import com.tngtech.archunit.junit.ArchTest;
+import com.tngtech.archunit.lang.ArchCondition;
 import com.tngtech.archunit.lang.ArchRule;
+import com.tngtech.archunit.lang.ConditionEvents;
+import com.tngtech.archunit.lang.SimpleConditionEvent;
+import dev.codesoapbox.backity.BackityApplication;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.params.ParameterizedTest;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
+import java.util.stream.Collectors;
 
-import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.*;
 import static org.assertj.core.api.Fail.fail;
 
 @SuppressWarnings("unused")
 public class TestRules {
+
+    static final List<String> TEST_SUFFIXES = List.of("Test", "IT");
+    static final String SHOULD_GIVEN_PATTERN = "(?i)(?=.*should)(?!.*given.*should).*";
+    static final String WHEN_PATTERN = ".*(?:^|[_\\W])when(?![a-z]).*|.*When(?![a-z]).*";
 
     @ArchTest
     static final ArchRule ASSERTJ_SHOULD_BE_USED_INSTEAD_OF_JUNIT_ASSERTIONS =
@@ -24,45 +35,213 @@ public class TestRules {
                     .because("AssertJ assertions provide a more fluent and expressive API," +
                             " offering a wider range of assertion options and clearer failure messages");
 
-    /**
-     * Ensures that all test classes with the same name as the class they're testing reside in the same package as that
-     * class. E.g. SomeClassTest should reside in the same package as SomeClass.
-     */
     @ArchTest
-    static void testClassesShouldResideInCorrectPackage(JavaClasses classes) {
-        Map<String, String> testNamesByPackage = getTestNamesByPackage(classes);
-        List<String> errors = findTestPackageViolations(classes, testNamesByPackage);
+    static final ArchRule DISABLED_TESTS_SHOULD_HAVE_A_REASON =
+            methods().that().areAnnotatedWith(Disabled.class)
+                    .should(haveNonBlankDisabledReason())
+                    .allowEmptyShould(true)
+                    .because("""
+                            disabled tests without a reason make it unclear why they were disabled \
+                            and whether they should be re-enabled or removed""");
+
+    @ArchTest
+    static final ArchRule DISABLED_TEST_CLASSES_SHOULD_HAVE_A_REASON =
+            classes().that().areAnnotatedWith(Disabled.class)
+                    .should(haveNonBlankDisabledReasonOnClass())
+                    .allowEmptyShould(true)
+                    .because("""
+                            disabled tests without a reason make it unclear why they were disabled \
+                            and whether they should be re-enabled or removed""");
+
+    @ArchTest
+    static final ArchRule TEST_NAMES_SHOULD_FOLLOW_PATTERN =
+            methods()
+                    .that().areAnnotatedWith(Test.class)
+                    .or().areAnnotatedWith(ParameterizedTest.class)
+                    .or().areAnnotatedWith(RepeatedTest.class)
+                    // No easy way to check this for TestFactory/TestTemplate
+                    .should(followShouldGivenConvention())
+                    .because("""
+                            consistency across the test suite improves readability and reduces
+                            cognitive overhead when navigating tests, while enforcing a
+                            'should ... (given) ...' structure clarifies intent by stating expected
+                            behavior before test context.
+                            """);
+
+    @ArchTest
+    static final ArchRule TEST_METHOD_NAMES_SHOULD_USE_GIVEN_INSTEAD_OF_WHEN =
+            methods()
+                    .that().areAnnotatedWith(Test.class)
+                    .or().areAnnotatedWith(ParameterizedTest.class)
+                    .or().areAnnotatedWith(RepeatedTest.class)
+                    .or().areAnnotatedWith(TestFactory.class)
+                    .or().areAnnotatedWith(TestTemplate.class)
+                    .should(notContainWhen())
+                    .because("""
+                            consistency across the test suite reduces cognitive overhead when \
+                            navigating tests and helps quickly identify intended behavior. \
+                            Use 'given' to describe context instead of 'when'.
+                            """);
+
+    private static ArchCondition<JavaMethod> followShouldGivenConvention() {
+        return new ArchCondition<>("follow 'should...(given)' naming convention") {
+
+            @Override
+            public void check(JavaMethod method, ConditionEvents events) {
+                Optional<String> displayName = resolveTestDisplayName(method);
+                boolean passes = method.getName().matches(SHOULD_GIVEN_PATTERN)
+                        || displayName.map(n -> n.matches(SHOULD_GIVEN_PATTERN)).orElse(false);
+
+                if (!passes) {
+                    events.add(SimpleConditionEvent.violated(method, String.format(
+                            "Method '%s'%s fails the 'should...given' pattern in %s",
+                            method.getOwner().getFullName() + "#" + method.getName(),
+                            displayName.map(n -> " (display name: '" + n + "')").orElse(""),
+                            method.getSourceCodeLocation()
+                    )));
+                }
+            }
+        };
+    }
+
+    private static ArchCondition<JavaMethod> notContainWhen() {
+        return new ArchCondition<>("not contain 'When' in name or display name") {
+
+            @Override
+            public void check(JavaMethod method, ConditionEvents events) {
+                Optional<String> displayName = resolveTestDisplayName(method);
+                boolean methodContainsWhen = method.getName().matches(WHEN_PATTERN);
+                boolean displayContainsWhen = displayName.map(n -> n.matches(WHEN_PATTERN))
+                        .orElse(false);
+
+                if (methodContainsWhen || displayContainsWhen) {
+                    events.add(SimpleConditionEvent.violated(method, String.format(
+                            "Method '%s'%s should use 'Given' instead of 'When' in %s",
+                            method.getOwner().getFullName() + "#" + method.getName(),
+                            displayName.map(n -> " (display name: '" + n + "')").orElse(""),
+                            method.getSourceCodeLocation()
+                    )));
+                }
+            }
+        };
+    }
+
+    private static ArchCondition<JavaMethod> haveNonBlankDisabledReason() {
+        return new ArchCondition<>("have a non-blank reason in @Disabled") {
+
+            @Override
+            public void check(JavaMethod method, ConditionEvents events) {
+                String reason = method.getAnnotationOfType(Disabled.class).value();
+                if (reason.isBlank()) {
+                    events.add(SimpleConditionEvent.violated(method, String.format(
+                            "Method '%s' is @Disabled without stating a reason in %s",
+                            method.getOwner().getFullName() + "#" + method.getName(),
+                            method.getSourceCodeLocation()
+                    )));
+                }
+            }
+        };
+    }
+
+    private static ArchCondition<JavaClass> haveNonBlankDisabledReasonOnClass() {
+        return new ArchCondition<>("have a non-blank reason in @Disabled") {
+
+            @Override
+            public void check(JavaClass javaClass, ConditionEvents events) {
+                String reason = javaClass.getAnnotationOfType(Disabled.class).value();
+                if (reason.isBlank()) {
+                    events.add(SimpleConditionEvent.violated(javaClass, String.format(
+                            "Class '%s' is @Disabled without stating a reason in %s",
+                            javaClass.getFullName(),
+                            javaClass.getSourceCodeLocation()
+                    )));
+                }
+            }
+        };
+    }
+
+    private static Optional<String> resolveTestDisplayName(JavaMethod method) {
+        if (method.isAnnotatedWith(DisplayName.class)) {
+            return Optional.of(method.getAnnotationOfType(DisplayName.class).value());
+        }
+        if (method.isAnnotatedWith(ParameterizedTest.class)) {
+            String name = method.getAnnotationOfType(ParameterizedTest.class).name();
+            if (!name.equals("{default_display_name}") && !name.isBlank()) {
+                return Optional.of(name);
+            }
+        }
+        if (method.isAnnotatedWith(RepeatedTest.class)) {
+            String name = method.getAnnotationOfType(RepeatedTest.class).name();
+            if (!name.equals(RepeatedTest.SHORT_DISPLAY_NAME) &&
+                    !name.equals(RepeatedTest.DISPLAY_NAME_PLACEHOLDER)) {
+                return Optional.of(name);
+            }
+        }
+        return Optional.empty();
+    }
+
+    /// Ensures that all test classes with the same name as the class they're testing reside in the same package as that
+    /// class. E.g., SomeClassTest should reside in the same package as SomeClass.
+    @ArchTest
+    static void testClassesShouldResideInCorrectPackage(JavaClasses testClasses) {
+        JavaClasses productionClasses = new ClassFileImporter()
+                .withImportOption(new ImportOption.DoNotIncludeTests())
+                .importPackagesOf(BackityApplication.class);
+
+        Map<String, List<JavaClass>> productionClassesBySimpleName = new HashMap<>();
+        for (JavaClass clazz : productionClasses) {
+            if (clazz.getEnclosingClass().isPresent()) {
+                continue; // Skip nested, inner, local, and anonymous classes
+            }
+            productionClassesBySimpleName
+                    .computeIfAbsent(clazz.getSimpleName(), k -> new ArrayList<>())
+                    .add(clazz);
+        }
+
+        List<String> errors = new ArrayList<>();
+        for (JavaClass testClass : testClasses) {
+            if (testClass.getEnclosingClass().isPresent()) {
+                continue; // Skip nested, inner, local, and anonymous classes
+            }
+
+            String testedSimpleName = stripTestSuffix(testClass.getSimpleName());
+            if (testedSimpleName.equals(testClass.getSimpleName())) {
+                continue; // Not a test class (no recognized suffix was stripped)
+            }
+
+            List<JavaClass> candidates = productionClassesBySimpleName.get(testedSimpleName);
+            if (candidates == null) {
+                continue;
+            }
+
+            boolean packageMatches = candidates.stream()
+                    .anyMatch(pc -> pc.getPackageName().equals(testClass.getPackageName()));
+
+            if (!packageMatches) {
+                String expectedPackages = candidates.stream()
+                        .map(JavaClass::getPackageName)
+                        .collect(Collectors.joining("] or ["));
+                errors.add(String.format(
+                        "%s should be in package [%s] but was found in [%s] %s",
+                        testClass.getSimpleName(),
+                        expectedPackages,
+                        testClass.getPackageName(),
+                        testClass.getSourceCodeLocation()
+                ));
+            }
+        }
 
         if (!errors.isEmpty()) {
             fail(String.join("\n", errors));
         }
     }
 
-    private static Map<String, String> getTestNamesByPackage(JavaClasses classes) {
-        Map<String, String> testNamesByPackage = new HashMap<>();
-        for (JavaClass clazz : classes) {
-            if (clazz.getName().endsWith("Test") || clazz.getName().endsWith("IT")) {
-                testNamesByPackage.put(clazz.getSimpleName(), clazz.getPackage().getName());
+    private static String stripTestSuffix(String simpleName) {
+        for (String suffix : TEST_SUFFIXES) {
+            if (simpleName.endsWith(suffix)) {
+                return simpleName.substring(0, simpleName.length() - suffix.length());
             }
         }
-        return testNamesByPackage;
-    }
-
-    private static List<String> findTestPackageViolations(JavaClasses classes, Map<String, String> testPackagesByName) {
-        List<String> errors = new ArrayList<>();
-
-        for (JavaClass classUnderTest : classes) {
-            String testName = classUnderTest.getSimpleName() + "Test";
-            String testPackage = testPackagesByName.get(testName);
-            boolean testExistsButIsInWrongPackage = testPackage != null
-                    && !testPackage.equals(classUnderTest.getPackage().getName());
-
-            if (testExistsButIsInWrongPackage) {
-                errors.add(String.format("Test class %s.%s is in the wrong package - should be in %s.",
-                        testPackage, testName, classUnderTest.getPackage().getName()));
-            }
-        }
-
-        return errors;
+        return simpleName;
     }
 }

--- a/backend/src/test/java/dev/codesoapbox/backity/core/backuptarget/domain/BackupTargetIdTest.java
+++ b/backend/src/test/java/dev/codesoapbox/backity/core/backuptarget/domain/BackupTargetIdTest.java
@@ -42,7 +42,7 @@ class BackupTargetIdTest {
     class Comparable {
 
         @Test
-        void shouldReturnZeroWhenComparingSameInstance() {
+        void shouldReturnZeroGivenComparingSameInstance() {
             var id1 = new BackupTargetId("d46dde81-e519-4300-9a54-6f9e7d637926");
 
             assertThat(id1).isEqualByComparingTo(id1);

--- a/backend/src/test/java/dev/codesoapbox/backity/core/backuptarget/domain/PathTemplateTest.java
+++ b/backend/src/test/java/dev/codesoapbox/backity/core/backuptarget/domain/PathTemplateTest.java
@@ -149,7 +149,7 @@ class PathTemplateTest {
             }
 
             @Test
-            void shouldResolveFilePathWhenNoSeparatorInPathTemplate() {
+            void shouldResolveFilePathGivenNoSeparatorInPathTemplate() {
                 SourceFile sourceFile = TestSourceFile.gogBuilder()
                         .gameProviderId(new GameProviderId("someGameProviderId"))
                         .originalGameTitle("someGameTitle")

--- a/backend/src/test/java/dev/codesoapbox/backity/core/discovery/application/GameContentDiscoveryServiceTest.java
+++ b/backend/src/test/java/dev/codesoapbox/backity/core/discovery/application/GameContentDiscoveryServiceTest.java
@@ -300,7 +300,7 @@ class GameContentDiscoveryServiceTest {
         }
 
         @Test
-        void startContentDiscoveryShouldSetGameProviderIdServiceAsNotInProgressWhenDone() {
+        void startContentDiscoveryShouldSetGameProviderIdServiceAsNotInProgressGivenDone() {
             gameContentDiscoveryService.startContentDiscovery();
 
             gameProviderFileDiscoveryService.complete();

--- a/backend/src/test/java/dev/codesoapbox/backity/core/filecopy/application/usecases/DeleteFileCopyUseCaseTest.java
+++ b/backend/src/test/java/dev/codesoapbox/backity/core/filecopy/application/usecases/DeleteFileCopyUseCaseTest.java
@@ -75,7 +75,7 @@ class DeleteFileCopyUseCaseTest {
     }
 
     @Test
-    void shouldChangeStatusOfFileCopyWhenDeletingFile() {
+    void shouldChangeStatusOfFileCopyGivenDeletingFile() {
         FileCopy fileCopy = mockStoredUnverifiedFileCopyExists();
         mockStorageSolutionExists(fileCopy);
 

--- a/backend/src/test/java/dev/codesoapbox/backity/core/filecopy/domain/FileCopyIdTest.java
+++ b/backend/src/test/java/dev/codesoapbox/backity/core/filecopy/domain/FileCopyIdTest.java
@@ -42,7 +42,7 @@ class FileCopyIdTest {
     class Comparable {
 
         @Test
-        void shouldReturnZeroWhenComparingSameInstance() {
+        void shouldReturnZeroGivenComparingSameInstance() {
             var id1 = new FileCopyId("9fdad52f-b4a6-46bc-af6d-bf27f9661eae");
 
             assertThat(id1).isEqualByComparingTo(id1);

--- a/backend/src/test/java/dev/codesoapbox/backity/core/filecopy/domain/FileCopyNaturalIdTest.java
+++ b/backend/src/test/java/dev/codesoapbox/backity/core/filecopy/domain/FileCopyNaturalIdTest.java
@@ -47,7 +47,7 @@ class FileCopyNaturalIdTest {
     class Comparable {
 
         @Test
-        void shouldReturnZeroWhenComparingSameInstance() {
+        void shouldReturnZeroGivenComparingSameInstance() {
             var id1 = new FileCopyNaturalId(
                     new SourceFileId("acde26d7-33c7-42ee-be16-bca91a604b48"),
                     new BackupTargetId("eda52c13-ddf7-406f-97d9-d3ce2cab5a76")

--- a/backend/src/test/java/dev/codesoapbox/backity/core/filecopy/infrastructure/adapters/driving/api/http/controllers/EnqueueFileCopyControllerIT.java
+++ b/backend/src/test/java/dev/codesoapbox/backity/core/filecopy/infrastructure/adapters/driving/api/http/controllers/EnqueueFileCopyControllerIT.java
@@ -54,7 +54,7 @@ class EnqueueFileCopyControllerIT {
     }
 
     @Test
-    void shouldReturnBadRequestWhenFileNotFound(CapturedOutput capturedOutput) throws Exception {
+    void shouldReturnBadRequestGivenFileNotFound(CapturedOutput capturedOutput) throws Exception {
         var sourceFileUuid = "acde26d7-33c7-42ee-be16-bca91a604b48";
         var backupTargetUuid = "224440e2-6e5c-4f24-94ac-3222587652f7";
         var sourceFileId = new SourceFileId(sourceFileUuid);

--- a/backend/src/test/java/dev/codesoapbox/backity/core/game/domain/GameIdTest.java
+++ b/backend/src/test/java/dev/codesoapbox/backity/core/game/domain/GameIdTest.java
@@ -42,7 +42,7 @@ class GameIdTest {
     class Comparable {
 
         @Test
-        void shouldReturnZeroWhenComparingSameInstance() {
+        void shouldReturnZeroGivenComparingSameInstance() {
             var id1 = new GameId("5bdd248a-c3aa-487a-8479-0bfdb32f7ae5");
 
             assertThat(id1).isEqualByComparingTo(id1);

--- a/backend/src/test/java/dev/codesoapbox/backity/core/game/infrastructure/adapters/driven/persistence/jpa/GameJpaRepositoryIT.java
+++ b/backend/src/test/java/dev/codesoapbox/backity/core/game/infrastructure/adapters/driven/persistence/jpa/GameJpaRepositoryIT.java
@@ -48,7 +48,7 @@ abstract class GameJpaRepositoryIT {
     }
 
     @Test
-    void shouldNotSaveWhenGameWithTitleAlreadyExists() {
+    void shouldNotSaveGivenGameWithTitleAlreadyExists() {
         populateDatabase(List.of(GAMES.GAME_1.get()));
         String existingTitle = GAMES.GAME_1.get().getTitle();
         Game game = TestGame.anyBuilder()

--- a/backend/src/test/java/dev/codesoapbox/backity/core/sourcefile/domain/SourceFileIdTest.java
+++ b/backend/src/test/java/dev/codesoapbox/backity/core/sourcefile/domain/SourceFileIdTest.java
@@ -42,7 +42,7 @@ class SourceFileIdTest {
     class Comparable {
 
         @Test
-        void shouldReturnZeroWhenComparingSameInstance() {
+        void shouldReturnZeroGivenComparingSameInstance() {
             var id1 = new SourceFileId("3b21cc23-54c6-48f3-914d-188b790128b4");
 
             assertThat(id1).isEqualByComparingTo(id1);

--- a/backend/src/test/java/dev/codesoapbox/backity/core/sourcefile/infrastructure/adapters/driven/persistence/jpa/SourceFileJpaEntityMapperTest.java
+++ b/backend/src/test/java/dev/codesoapbox/backity/core/sourcefile/infrastructure/adapters/driven/persistence/jpa/SourceFileJpaEntityMapperTest.java
@@ -1,9 +1,7 @@
-package dev.codesoapbox.backity.core.sourcefile.adapters.driven.persistence.jpa;
+package dev.codesoapbox.backity.core.sourcefile.infrastructure.adapters.driven.persistence.jpa;
 
 import dev.codesoapbox.backity.core.sourcefile.domain.SourceFile;
 import dev.codesoapbox.backity.core.sourcefile.domain.TestSourceFile;
-import dev.codesoapbox.backity.core.sourcefile.infrastructure.adapters.driven.persistence.jpa.SourceFileJpaEntity;
-import dev.codesoapbox.backity.core.sourcefile.infrastructure.adapters.driven.persistence.jpa.SourceFileJpaEntityMapper;
 import org.junit.jupiter.api.Test;
 import org.mapstruct.factory.Mappers;
 

--- a/backend/src/test/java/dev/codesoapbox/backity/core/sourcefile/infrastructure/adapters/driven/persistence/jpa/SourceFileJpaRepositoryIT.java
+++ b/backend/src/test/java/dev/codesoapbox/backity/core/sourcefile/infrastructure/adapters/driven/persistence/jpa/SourceFileJpaRepositoryIT.java
@@ -1,4 +1,4 @@
-package dev.codesoapbox.backity.core.sourcefile.adapters.driven.persistence.jpa;
+package dev.codesoapbox.backity.core.sourcefile.infrastructure.adapters.driven.persistence.jpa;
 
 import dev.codesoapbox.backity.core.game.domain.Game;
 import dev.codesoapbox.backity.core.game.domain.GameId;
@@ -7,9 +7,6 @@ import dev.codesoapbox.backity.core.sourcefile.domain.SourceFile;
 import dev.codesoapbox.backity.core.sourcefile.domain.SourceFileId;
 import dev.codesoapbox.backity.core.sourcefile.domain.TestSourceFile;
 import dev.codesoapbox.backity.core.sourcefile.domain.exceptions.SourceFileNotFoundException;
-import dev.codesoapbox.backity.core.sourcefile.infrastructure.adapters.driven.persistence.jpa.SourceFileJpaEntity;
-import dev.codesoapbox.backity.core.sourcefile.infrastructure.adapters.driven.persistence.jpa.SourceFileJpaEntityMapper;
-import dev.codesoapbox.backity.core.sourcefile.infrastructure.adapters.driven.persistence.jpa.SourceFileJpaRepository;
 import dev.codesoapbox.backity.shared.domain.DomainEventPublisher;
 import dev.codesoapbox.backity.testing.jpa.annotations.MultiDatabaseRepositoryTest;
 import org.junit.jupiter.api.BeforeEach;

--- a/backend/src/test/java/dev/codesoapbox/backity/core/sourcefile/infrastructure/adapters/driving/api/http/model/sourcefile/SourceFileHttpDtoMapperTest.java
+++ b/backend/src/test/java/dev/codesoapbox/backity/core/sourcefile/infrastructure/adapters/driving/api/http/model/sourcefile/SourceFileHttpDtoMapperTest.java
@@ -1,9 +1,7 @@
-package dev.codesoapbox.backity.core.sourcefile.adapters.driving.api.http.model.sourcefile;
+package dev.codesoapbox.backity.core.sourcefile.infrastructure.adapters.driving.api.http.model.sourcefile;
 
 import dev.codesoapbox.backity.core.sourcefile.domain.SourceFile;
 import dev.codesoapbox.backity.core.sourcefile.domain.TestSourceFile;
-import dev.codesoapbox.backity.core.sourcefile.infrastructure.adapters.driving.api.http.model.sourcefile.SourceFileHttpDto;
-import dev.codesoapbox.backity.core.sourcefile.infrastructure.adapters.driving.api.http.model.sourcefile.SourceFileHttpDtoMapper;
 import org.junit.jupiter.api.Test;
 import org.mapstruct.factory.Mappers;
 

--- a/backend/src/test/java/dev/codesoapbox/backity/core/storagesolution/domain/StorageSolutionIdTest.java
+++ b/backend/src/test/java/dev/codesoapbox/backity/core/storagesolution/domain/StorageSolutionIdTest.java
@@ -30,7 +30,7 @@ class StorageSolutionIdTest {
     class Comparable {
 
         @Test
-        void shouldReturnZeroWhenComparingSameInstance() {
+        void shouldReturnZeroGivenComparingSameInstance() {
             var id1 = new StorageSolutionId("S3");
 
             assertThat(id1).isEqualByComparingTo(id1);

--- a/backend/src/test/java/dev/codesoapbox/backity/core/storagesolution/infrastructure/adapters/driven/filesystem/S3OutputStreamTest.java
+++ b/backend/src/test/java/dev/codesoapbox/backity/core/storagesolution/infrastructure/adapters/driven/filesystem/S3OutputStreamTest.java
@@ -185,7 +185,7 @@ class S3OutputStreamTest {
     }
 
     @Test
-    void writeShouldFlushBufferAndUploadPartsWithCorrectNumbersWhenFull() {
+    void writeShouldFlushBufferAndUploadPartsWithCorrectNumbersGivenFull() {
         mockMultipartUploadCreationAndPartUpload();
         var fullBufferData = new byte[BUFFER_SIZE_BYTES];
         s3OutputStream.write(fullBufferData); // Triggers multipart upload creation and first part upload
@@ -222,7 +222,7 @@ class S3OutputStreamTest {
     }
 
     @Test
-    void shouldThrowExceptionWhenWritingToClosedStream() {
+    void shouldThrowExceptionGivenWritingToClosedStream() {
         s3OutputStream.close();
 
         assertThatWritingToStreamCausesException();

--- a/backend/src/test/java/dev/codesoapbox/backity/gameproviders/shared/infrastructure/adapters/driven/api/spring/DataBufferFluxTrackableFileStreamTest.java
+++ b/backend/src/test/java/dev/codesoapbox/backity/gameproviders/shared/infrastructure/adapters/driven/api/spring/DataBufferFluxTrackableFileStreamTest.java
@@ -1,14 +1,14 @@
 package dev.codesoapbox.backity.gameproviders.shared.infrastructure.adapters.driven.api.spring;
 
 import dev.codesoapbox.backity.core.backup.application.WriteDestination;
-import dev.codesoapbox.backity.core.backup.application.writeprogress.OutputStreamProgressTracker;
-import dev.codesoapbox.backity.shared.application.progress.ProgressInfo;
 import dev.codesoapbox.backity.core.backup.application.exceptions.ConcurrentFileWriteException;
-import dev.codesoapbox.backity.core.backup.application.exceptions.StorageSolutionWriteFailedException;
 import dev.codesoapbox.backity.core.backup.application.exceptions.FileWriteWasCanceledException;
+import dev.codesoapbox.backity.core.backup.application.exceptions.StorageSolutionWriteFailedException;
+import dev.codesoapbox.backity.core.backup.application.writeprogress.OutputStreamProgressTracker;
 import dev.codesoapbox.backity.core.storagesolution.domain.FakeUnixStorageSolution;
 import dev.codesoapbox.backity.gameproviders.gog.infrastructure.adapters.driven.api.embed.testing.TestDataBufferFlux;
 import dev.codesoapbox.backity.gameproviders.gog.infrastructure.adapters.driven.api.embed.testing.TestFlux;
+import dev.codesoapbox.backity.shared.application.progress.ProgressInfo;
 import dev.codesoapbox.backity.testing.time.FakeClock;
 import io.netty.handler.codec.dns.DefaultDnsQuestion;
 import io.netty.handler.codec.dns.DnsRecordType;
@@ -220,9 +220,9 @@ class DataBufferFluxTrackableFileStreamTest {
                 );
             }
 
-            @ParameterizedTest(name = "should throw when canceled {0}")
+            @ParameterizedTest(name = "should throw given canceled {0}")
             @MethodSource("cancelScenarios")
-            void shouldThrowWhenCanceled(String scenarioName, Flux<Boolean> cancelFlux) {
+            void shouldThrowGivenCanceled(String scenarioName, Flux<Boolean> cancelFlux) {
                 TestFlux<DataBuffer> dataBufferFlux = TestDataBufferFlux.succeeding();
                 OutputStreamProgressTracker progress = initializedOutputStreamProgressTrackerFor(dataBufferFlux.data());
                 var fileStream =

--- a/backend/src/test/java/dev/codesoapbox/backity/shared/application/eventhandlers/exceptions/DomainEventForwardingHandlerExceptionTest.java
+++ b/backend/src/test/java/dev/codesoapbox/backity/shared/application/eventhandlers/exceptions/DomainEventForwardingHandlerExceptionTest.java
@@ -1,6 +1,5 @@
-package dev.codesoapbox.backity.shared.application.eventhandlers;
+package dev.codesoapbox.backity.shared.application.eventhandlers.exceptions;
 
-import dev.codesoapbox.backity.shared.application.eventhandlers.exceptions.DomainEventForwardingHandlerException;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/backend/src/test/java/dev/codesoapbox/backity/shared/application/progress/ProgressTrackerTest.java
+++ b/backend/src/test/java/dev/codesoapbox/backity/shared/application/progress/ProgressTrackerTest.java
@@ -105,7 +105,7 @@ class ProgressTrackerTest {
             );
         }
 
-        @ParameterizedTest(name = "when {0}")
+        @ParameterizedTest(name = "given {0}")
         @MethodSource("progressArguments")
         void getProgressInfoShouldShowCorrectProgress(Integer trackerIncrement, Integer timeOffset,
                                                       Integer expectedPercentage, Long expectedSecondsLeft) {
@@ -119,7 +119,7 @@ class ProgressTrackerTest {
         }
 
         @Test
-        void getProgressInfoShouldShowNoProgressWhenNeverIncremented() {
+        void getProgressInfoShouldShowNoProgressGivenNeverIncremented() {
             var tracker = new ProgressTracker(10L, clock);
             ProgressInfo progressInfo = tracker.getProgressInfo();
 

--- a/backend/src/test/java/dev/codesoapbox/backity/shared/infrastructure/adapters/driving/api/http/lowercaseenums/LowercaseEnumFinderTest.java
+++ b/backend/src/test/java/dev/codesoapbox/backity/shared/infrastructure/adapters/driving/api/http/lowercaseenums/LowercaseEnumFinderTest.java
@@ -30,7 +30,7 @@ class LowercaseEnumFinderTest {
     }
 
     @Test
-    void testGetAnnotatedControllerEnums() {
+    void getAnnotatedControllerEnumsShouldReturnEnumsAnnotatedWithLowercaseApiEnum() {
         when(applicationContext.getBeanNamesForAnnotation(RestController.class))
                 .thenReturn(new String[]{"testController"});
         doReturn(TestController.class)

--- a/backend/src/test/java/dev/codesoapbox/backity/shared/infrastructure/adapters/driving/api/http/lowercaseenums/openapi/SwaggerEnumLowerCaseModelConverterTest.java
+++ b/backend/src/test/java/dev/codesoapbox/backity/shared/infrastructure/adapters/driving/api/http/lowercaseenums/openapi/SwaggerEnumLowerCaseModelConverterTest.java
@@ -115,7 +115,7 @@ class SwaggerEnumLowerCaseModelConverterTest {
     }
 
     @Test
-    void shouldDelegateResolutionWhenNotEnum() {
+    void shouldDelegateResolutionGivenNotEnum() {
         AnnotatedType annotatedType = getAnnotatedTypeFromArgumentAsSimpleType(
                 "testMethodWithoutEnumWithAnnotation", TestRecord.class);
 
@@ -130,7 +130,7 @@ class SwaggerEnumLowerCaseModelConverterTest {
     }
 
     @Test
-    void shouldReturnNullWhenIteratorEmpty() {
+    void shouldReturnNullGivenIteratorEmpty() {
         AnnotatedType annotatedType = getAnnotatedTypeFromArgumentAsSimpleType(
                 "testMethodWithoutEnumWithoutAnnotation", Object.class);
 

--- a/backend/src/test/java/dev/codesoapbox/backity/shared/infrastructure/config/events/DomainEventForwarderFinderIT.java
+++ b/backend/src/test/java/dev/codesoapbox/backity/shared/infrastructure/config/events/DomainEventForwarderFinderIT.java
@@ -1,8 +1,7 @@
-package dev.codesoapbox.backity.shared.infrastructure.adapters.driven.messaging.ws;
+package dev.codesoapbox.backity.shared.infrastructure.config.events;
 
 import dev.codesoapbox.backity.shared.application.eventhandlers.DomainEventForwarder;
 import dev.codesoapbox.backity.shared.application.eventhandlers.DomainEventForwardingHandler;
-import dev.codesoapbox.backity.shared.infrastructure.config.events.DomainEventForwarderFinder;
 import dev.codesoapbox.backity.shared.infrastructure.config.events.exceptions.DomainEventForwarderException;
 import lombok.Getter;
 import lombok.Setter;

--- a/backend/src/test/java/dev/codesoapbox/backity/shared/infrastructure/config/events/exceptions/DomainEventForwarderExceptionTest.java
+++ b/backend/src/test/java/dev/codesoapbox/backity/shared/infrastructure/config/events/exceptions/DomainEventForwarderExceptionTest.java
@@ -1,6 +1,5 @@
-package dev.codesoapbox.backity.shared.infrastructure.config.events;
+package dev.codesoapbox.backity.shared.infrastructure.config.events.exceptions;
 
-import dev.codesoapbox.backity.shared.infrastructure.config.events.exceptions.DomainEventForwarderException;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/backend/src/test/java/dev/codesoapbox/backity/shared/infrastructure/config/openapi/GenericsFixingModelConverterTest.java
+++ b/backend/src/test/java/dev/codesoapbox/backity/shared/infrastructure/config/openapi/GenericsFixingModelConverterTest.java
@@ -75,7 +75,7 @@ class GenericsFixingModelConverterTest {
     }
 
     @Test
-    void shouldDoNothingWhenResolvedSchemaIsNull() {
+    void shouldDoNothingGivenResolvedSchemaIsNull() {
         modelConverters.addConverter((annotatedType, modelConverterContext, iterator) -> null);
         registerModelConverter();
         AnnotatedType annotatedType = constructAnnotatedType(TestRecordWithoutAnnotation.class);
@@ -86,7 +86,7 @@ class GenericsFixingModelConverterTest {
     }
 
     @Test
-    void shouldDoNothingWhenResolvedSchemaTypeIsNotNull() {
+    void shouldDoNothingGivenResolvedSchemaTypeIsNotNull() {
         var schema = new io.swagger.v3.oas.models.media.Schema<>();
         schema.type("object");
         modelConverters.addConverter((annotatedType, modelConverterContext, iterator) -> schema);
@@ -99,7 +99,7 @@ class GenericsFixingModelConverterTest {
     }
 
     @Test
-    void shouldDoNothingWhenJavaTypeIsNull() {
+    void shouldDoNothingGivenJavaTypeIsNull() {
         io.swagger.v3.oas.models.media.Schema<Object> schema = new io.swagger.v3.oas.models.media.Schema<>();
         modelConverters.addConverter((annotatedType, modelConverterContext, iterator) -> schema);
         registerModelConverterWithMockObjectMapperProvider();
@@ -121,7 +121,7 @@ class GenericsFixingModelConverterTest {
     }
 
     @Test
-    void shouldDoNothingWhenClassHasNoGenericTypes() {
+    void shouldDoNothingGivenClassHasNoGenericTypes() {
         io.swagger.v3.oas.models.media.Schema<Object> schema = new io.swagger.v3.oas.models.media.Schema<>();
         modelConverters.addConverter((annotatedType, modelConverterContext, iterator) -> schema);
         registerModelConverter();
@@ -134,7 +134,7 @@ class GenericsFixingModelConverterTest {
     }
 
     @Test
-    void shouldDoNothingWhenRefIsEmpty() {
+    void shouldDoNothingGivenRefIsEmpty() {
         io.swagger.v3.oas.models.media.Schema<Object> schema = new io.swagger.v3.oas.models.media.Schema<>();
         modelConverters.addConverter((annotatedType, modelConverterContext, iterator) -> schema);
         registerModelConverter();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added automated rules enforcing JUnit naming/display conventions (favoring "Given" phrasing) and requiring non-blank reasons for disabled tests.
  * Renamed many test methods and display names to align with the new convention for clarity and consistency.
  * Reorganized test packages and imports to reflect updated test structure and validation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->