### PR TITLE
test: Allow disabling auditing through EntityAuditControl

### DIFF
--- a/backend/src/main/java/dev/codesoapbox/backity/core/game/domain/Game.java
+++ b/backend/src/main/java/dev/codesoapbox/backity/core/game/domain/Game.java
@@ -7,6 +7,7 @@ import java.time.LocalDateTime;
 @EqualsAndHashCode(onlyExplicitlyIncluded = true)
 @AllArgsConstructor
 @Getter
+@ToString
 public class Game {
 
     @EqualsAndHashCode.Include

--- a/backend/src/main/java/dev/codesoapbox/backity/shared/infrastructure/config/TimeBeanConfig.java
+++ b/backend/src/main/java/dev/codesoapbox/backity/shared/infrastructure/config/TimeBeanConfig.java
@@ -1,9 +1,15 @@
 package dev.codesoapbox.backity.shared.infrastructure.config;
 
 import dev.codesoapbox.backity.shared.infrastructure.config.slices.SystemServiceBeanConfiguration;
+import org.springframework.boot.validation.autoconfigure.ValidationConfigurationCustomizer;
 import org.springframework.context.annotation.Bean;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.auditing.DateTimeProvider;
 
 import java.time.Clock;
+import java.time.LocalDateTime;
+import java.util.Optional;
 
 @SystemServiceBeanConfiguration
 public class TimeBeanConfig {
@@ -11,5 +17,17 @@ public class TimeBeanConfig {
     @Bean
     Clock clock() {
         return Clock.systemUTC();
+    }
+
+    /// Provides time for bean validation
+    @Bean
+    ValidationConfigurationCustomizer validationConfigurationCustomizer(Clock clock) {
+        return c -> c.clockProvider(() -> clock);
+    }
+
+    /// Provides time for entity auditing ([CreatedDate], [LastModifiedDate])
+    @Bean
+    DateTimeProvider auditingDateTimeProvider(Clock clock) {
+        return () -> Optional.of(LocalDateTime.now(clock));
     }
 }

--- a/backend/src/test/java/dev/codesoapbox/backity/core/backuptarget/infrastructure/adapters/driven/persistence/jpa/BackupTargetJpaRepositoryIT.java
+++ b/backend/src/test/java/dev/codesoapbox/backity/core/backuptarget/infrastructure/adapters/driven/persistence/jpa/BackupTargetJpaRepositoryIT.java
@@ -6,13 +6,13 @@ import dev.codesoapbox.backity.core.backuptarget.domain.BackupTargetName;
 import dev.codesoapbox.backity.core.backuptarget.domain.TestBackupTarget;
 import dev.codesoapbox.backity.core.backuptarget.domain.exceptions.BackupTargetNotFoundException;
 import dev.codesoapbox.backity.testing.jpa.annotations.MultiDatabaseRepositoryTest;
+import dev.codesoapbox.backity.testing.jpa.extensions.EntityAuditControl;
+import dev.codesoapbox.backity.testing.time.FakeClock;
 import dev.codesoapbox.backity.testing.time.config.FakeTimeBeanConfig;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.jpa.test.autoconfigure.TestEntityManager;
-import org.springframework.data.auditing.AuditingHandler;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
@@ -21,8 +21,6 @@ import java.util.function.Supplier;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.doAnswer;
 
 @MultiDatabaseRepositoryTest
 @Transactional // Required by @JpaRepositoryTest
@@ -41,14 +39,12 @@ abstract class BackupTargetJpaRepositoryIT {
     protected BackupTargetJpaEntityMapper entityMapper;
 
     @Autowired
-    private AuditingHandler auditingHandlerSpy;
+    protected FakeClock clock;
 
+    @SuppressWarnings("JUnitMalformedDeclaration")
     @BeforeEach
-    void setUp() {
-        // Prevent Spring Data JPA auditing from overwriting preset @CreatedDate/@LastModifiedDate values
-        // during test data setup:
-        doAnswer(inv -> inv)
-                .when(auditingHandlerSpy).markCreated(any());
+    void setUp(EntityAuditControl entityAuditControl) {
+        entityAuditControl.disable();
     }
 
     @Test
@@ -73,10 +69,11 @@ abstract class BackupTargetJpaRepositoryIT {
         assertThat.wasPersistedWithAllData(backupTarget);
     }
 
+    @SuppressWarnings("JUnitMalformedDeclaration")
     @Test
-    void saveShouldUpdateDates() {
-        Mockito.reset(auditingHandlerSpy);
-        BackupTarget backupTarget = SampleBackupTargets.TODAY_LOCAL_FOLDER.get();
+    void saveShouldUpdateDates(EntityAuditControl entityAuditControl) {
+        entityAuditControl.enable();
+        BackupTarget backupTarget = SampleBackupTargets.YESTERDAY_LOCAL_FOLDER.get();
 
         repository.save(backupTarget);
         entityManager.flush();
@@ -201,22 +198,25 @@ abstract class BackupTargetJpaRepositoryIT {
 
     private class Assertions {
 
-        private static final String[] ENTITY_FIELDS_TO_IGNORE = {"dateCreated", "dateModified"};
-
         void datesWereUpdatedByAuditingHandler(BackupTarget backupTarget) {
+            LocalDateTime now = LocalDateTime.now(clock);
             BackupTargetJpaEntity persistedEntity = getPersistedEntity(backupTarget.getId());
-            assertThat(persistedEntity.getDateCreated()).isNotEqualTo(backupTarget.getDateCreated());
-            assertThat(persistedEntity.getDateModified()).isNotEqualTo(backupTarget.getDateModified());
+            assertThat(persistedEntity.getDateCreated())
+                    .isNotEqualTo(backupTarget.getDateCreated())
+                    .isEqualTo(now);
+            assertThat(persistedEntity.getDateModified())
+                    .isNotEqualTo(backupTarget.getDateModified())
+                    .isEqualTo(now);
+        }
+
+        private BackupTargetJpaEntity getPersistedEntity(BackupTargetId id) {
+            return entityManager.find(BackupTargetJpaEntity.class, id.value());
         }
 
         void wasPersistedWithAllData(BackupTarget expected) {
             BackupTargetJpaEntity persistedEntity = getPersistedEntity(expected.getId());
             BackupTarget persisted = entityMapper.toDomain(persistedEntity);
             allDataIsSame(persisted, expected);
-        }
-
-        private BackupTargetJpaEntity getPersistedEntity(BackupTargetId id) {
-            return entityManager.find(BackupTargetJpaEntity.class, id.value());
         }
 
         void allDataIsSame(BackupTarget actual, BackupTarget expected) {
@@ -227,13 +227,12 @@ abstract class BackupTargetJpaRepositoryIT {
                         assertThat(it.getDateModified()).isNotNull();
                     })
                     .usingRecursiveComparison()
-                    .ignoringFields(ENTITY_FIELDS_TO_IGNORE)
                     .isEqualTo(expected);
         }
 
         void containsOnlyWithAllData(List<BackupTarget> actual, BackupTarget expected) {
             assertThat(actual)
-                    .usingRecursiveFieldByFieldElementComparatorIgnoringFields(ENTITY_FIELDS_TO_IGNORE)
+                    .usingRecursiveFieldByFieldElementComparator()
                     .containsExactly(expected);
         }
 

--- a/backend/src/test/java/dev/codesoapbox/backity/core/discovery/infrastructure/adapters/driven/persistence/jpa/GameContentDiscoveryResultJpaRepositoryIT.java
+++ b/backend/src/test/java/dev/codesoapbox/backity/core/discovery/infrastructure/adapters/driven/persistence/jpa/GameContentDiscoveryResultJpaRepositoryIT.java
@@ -37,7 +37,7 @@ abstract class GameContentDiscoveryResultJpaRepositoryIT {
     }
 
     private void persistExistingDependencies() {
-        for (GameContentDiscoveryResult discoveryResult : EXISTING_DISCOVERY_RESULTS.getAll()) {
+        for (GameContentDiscoveryResult discoveryResult : SampleDiscoveryResults.getAll()) {
             entityManager.persist(entityMapper.toEntity(discoveryResult));
         }
     }
@@ -74,7 +74,7 @@ abstract class GameContentDiscoveryResultJpaRepositoryIT {
 
     @Test
     void saveShouldReplaceExisting() {
-        GameContentDiscoveryResult discoveryResult = EXISTING_DISCOVERY_RESULTS.GOG_DISCOVERY_RESULT.get();
+        GameContentDiscoveryResult discoveryResult = SampleDiscoveryResults.GOG_DISCOVERY_RESULT.get();
         discoveryResult.setGamesDiscovered(999);
         repository.save(discoveryResult);
         entityManager.flush();
@@ -87,12 +87,12 @@ abstract class GameContentDiscoveryResultJpaRepositoryIT {
 
     private void assertDidNotCreateNewDbRow() {
         long numberOfRecordsInDb = springRepository.count();
-        assertThat(numberOfRecordsInDb).isEqualTo(EXISTING_DISCOVERY_RESULTS.getAll().size());
+        assertThat(numberOfRecordsInDb).isEqualTo(SampleDiscoveryResults.getAll().size());
     }
 
     @Test
     void shouldFindAllByGameProviderIdIn() {
-        GameContentDiscoveryResult expectedDiscoveryResult = EXISTING_DISCOVERY_RESULTS.GOG_DISCOVERY_RESULT.get();
+        GameContentDiscoveryResult expectedDiscoveryResult = SampleDiscoveryResults.GOG_DISCOVERY_RESULT.get();
 
         List<GameContentDiscoveryResult> result = repository.findAllByGameProviderIdIn(
                 List.of(expectedDiscoveryResult.getGameProviderId()));
@@ -100,7 +100,7 @@ abstract class GameContentDiscoveryResultJpaRepositoryIT {
         assertThat(result).containsExactly(expectedDiscoveryResult);
     }
 
-    private static class EXISTING_DISCOVERY_RESULTS {
+    private static class SampleDiscoveryResults {
 
         public static final Supplier<GameContentDiscoveryResult> GOG_DISCOVERY_RESULT =
                 TestGameContentDiscoveryResult::gog;

--- a/backend/src/test/java/dev/codesoapbox/backity/core/filecopy/infrastructure/adapters/driven/persistence/jpa/FileCopyJpaRepositoryIT.java
+++ b/backend/src/test/java/dev/codesoapbox/backity/core/filecopy/infrastructure/adapters/driven/persistence/jpa/FileCopyJpaRepositoryIT.java
@@ -22,8 +22,11 @@ import dev.codesoapbox.backity.shared.domain.Pagination;
 import dev.codesoapbox.backity.shared.infrastructure.adapters.driven.persistence.jpa.SpringPageMapper;
 import dev.codesoapbox.backity.shared.infrastructure.adapters.driven.persistence.jpa.SpringPageableMapper;
 import dev.codesoapbox.backity.testing.jpa.annotations.MultiDatabaseRepositoryTest;
+import dev.codesoapbox.backity.testing.jpa.extensions.EntityAuditControl;
+import dev.codesoapbox.backity.testing.time.FakeClock;
 import dev.codesoapbox.backity.testing.time.config.FakeTimeBeanConfig;
 import org.hibernate.exception.ConstraintViolationException;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mapstruct.factory.Mappers;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -54,6 +57,8 @@ abstract class FileCopyJpaRepositoryIT {
     private static final LocalDate YESTERDAY = TODAY.minusDays(1);
     private static final LocalDate BEFORE_YESTERDAY = TODAY.minusDays(2);
 
+    private final Assertions assertThat = new Assertions();
+
     @Autowired
     protected FileCopyJpaRepository repository;
 
@@ -66,9 +71,30 @@ abstract class FileCopyJpaRepositoryIT {
     @Autowired
     protected DomainEventPublisher domainEventPublisher;
 
-    private void persistSampleData() {
+    @Autowired
+    protected FakeClock clock;
+
+    @SuppressWarnings("JUnitMalformedDeclaration")
+    @BeforeEach
+    void setUp(EntityAuditControl entityAuditControl) {
+        entityAuditControl.disable();
+    }
+
+    @Test
+    void saveShouldPersistNew() {
         persistSampleDependencies();
-        persistFileCopies(SampleFileCopies.getAll());
+        FileCopy fileCopy = TestFileCopy.trackedBuilder()
+                .naturalId(new FileCopyNaturalId(
+                        SampleSourceFiles.GOG_SOURCE_FILE_1_FOR_GAME_1.get().getId(),
+                        SampleBackupTargets.LOCAL_FOLDER_1.get().getId()
+                ))
+                .build();
+
+        FileCopy result = repository.save(fileCopy);
+        entityManager.flush();
+
+        assertSame(result, fileCopy);
+        assertWasPersisted(fileCopy);
     }
 
     private void persistSampleDependencies() {
@@ -95,41 +121,6 @@ abstract class FileCopyJpaRepositoryIT {
         }
     }
 
-    private void persistFileCopies(List<FileCopy> fileCopies) {
-        for (FileCopy fileCopy : fileCopies) {
-            entityManager.persist(entityMapper.toEntity(fileCopy));
-            updateDateModified(fileCopy);
-        }
-    }
-
-    /*
-    DateModified gets overwritten by the database on every INSERT/UPDATE, so we need to update it manually.
-     */
-    private void updateDateModified(FileCopy fileCopy) {
-        entityManager.getEntityManager()
-                .createQuery("UPDATE FileCopy f SET f.dateModified = :date WHERE f.id = :id")
-                .setParameter("date", fileCopy.getDateModified())
-                .setParameter("id", fileCopy.getId().value())
-                .executeUpdate();
-    }
-
-    @Test
-    void saveShouldPersistNew() {
-        persistSampleDependencies();
-        FileCopy fileCopy = TestFileCopy.trackedBuilder()
-                .naturalId(new FileCopyNaturalId(
-                        SampleSourceFiles.GOG_SOURCE_FILE_1_FOR_GAME_1.get().getId(),
-                        SampleBackupTargets.LOCAL_FOLDER_1.get().getId()
-                ))
-                .build();
-
-        FileCopy result = repository.save(fileCopy);
-        entityManager.flush();
-
-        assertSame(result, fileCopy);
-        assertWasPersisted(fileCopy);
-    }
-
     private void assertWasPersisted(FileCopy fileCopy) {
         FileCopyJpaEntity persistedEntity = entityManager.find(FileCopyJpaEntity.class, fileCopy.getId().value());
         FileCopy persistedFileCopy = entityMapper.toDomain(persistedEntity);
@@ -143,7 +134,6 @@ abstract class FileCopyJpaRepositoryIT {
                     assertThat(it.getDateModified()).isNotNull();
                 })
                 .usingRecursiveComparison()
-                .ignoringFields("dateCreated", "dateModified")
                 .isEqualTo(expected);
     }
 
@@ -159,6 +149,30 @@ abstract class FileCopyJpaRepositoryIT {
 
         assertSame(result, fileCopy);
         assertWasPersisted(fileCopy);
+    }
+
+    private void persistSampleData() {
+        persistSampleDependencies();
+        persistFileCopies(SampleFileCopies.getAll());
+    }
+
+    private void persistFileCopies(List<FileCopy> fileCopies) {
+        for (FileCopy fileCopy : fileCopies) {
+            entityManager.persist(entityMapper.toEntity(fileCopy));
+        }
+    }
+
+    @SuppressWarnings("JUnitMalformedDeclaration")
+    @Test
+    void saveShouldUpdateDates(EntityAuditControl entityAuditControl) {
+        persistSampleDependencies();
+        entityAuditControl.enable();
+        FileCopy fileCopy = SampleFileCopies.TRACKED_FILE_COPY_FROM_YESTERDAY_FOR_SOURCE_FILE_1.get();
+
+        repository.save(fileCopy);
+        entityManager.flush();
+
+        assertThat.datesWereUpdatedByAuditingHandler(fileCopy);
     }
 
     @Test
@@ -321,7 +335,6 @@ abstract class FileCopyJpaRepositoryIT {
     private void assertSame(Page<FileCopy> result, Page<FileCopy> expectedResult) {
         assertThat(result)
                 .usingRecursiveComparison()
-                .ignoringFields("content.dateCreated", "content.dateModified")
                 .isEqualTo(expectedResult);
         assertThat(result.content()).containsExactlyElementsOf(expectedResult.content());
     }
@@ -340,7 +353,6 @@ abstract class FileCopyJpaRepositoryIT {
     private void assertSame(List<FileCopy> result, List<FileCopy> expectedResult) {
         assertThat(result)
                 .usingRecursiveComparison()
-                .ignoringFields("dateCreated", "dateModified")
                 .isEqualTo(expectedResult);
         assertThat(result).containsExactlyElementsOf(expectedResult);
     }
@@ -356,7 +368,6 @@ abstract class FileCopyJpaRepositoryIT {
                 SampleFileCopies.TRACKED_FILE_COPY_FROM_TODAY_FOR_SOURCE_FILE_1.get()
         );
         assertThat(result)
-                .usingRecursiveFieldByFieldElementComparatorIgnoringFields("dateCreated", "dateModified")
                 .containsExactlyElementsOf(expectedResult);
     }
 
@@ -481,8 +492,6 @@ abstract class FileCopyJpaRepositoryIT {
 
     private static class SampleBackupTargets {
 
-        private static final BackupTargetJpaEntityMapper MAPPER = Mappers.getMapper(BackupTargetJpaEntityMapper.class);
-
         public static final Supplier<BackupTarget> LOCAL_FOLDER_1 = () -> TestBackupTarget.localFolderBuilder()
                 .withId(new BackupTargetId("eda52c13-ddf7-406f-97d9-d3ce2cab5a76"))
                 .build();
@@ -514,6 +523,8 @@ abstract class FileCopyJpaRepositoryIT {
         public static final Supplier<BackupTarget> LOCAL_FOLDER_8 = () -> TestBackupTarget.localFolderBuilder()
                 .withId(new BackupTargetId("03468b45-7152-4026-b416-6a2602bf0c1c"))
                 .build();
+
+        private static final BackupTargetJpaEntityMapper MAPPER = Mappers.getMapper(BackupTargetJpaEntityMapper.class);
 
         public static List<BackupTarget> getAll() {
             return List.of(
@@ -630,6 +641,24 @@ abstract class FileCopyJpaRepositoryIT {
                     STORED_VERIFIED_FILE_COPY_FROM_BEFORE_YESTERDAY_FOR_SOURCE_FILE_2.get(),
                     FAILED_FILE_COPY_FROM_TODAY_FOR_SOURCE_FILE_2.get()
             );
+        }
+    }
+
+    private class Assertions {
+
+        void datesWereUpdatedByAuditingHandler(FileCopy fileCopy) {
+            LocalDateTime now = LocalDateTime.now(clock);
+            FileCopyJpaEntity persistedEntity = getPersistedEntity(fileCopy.getId());
+            assertThat(persistedEntity.getDateCreated())
+                    .isNotEqualTo(fileCopy.getDateCreated())
+                    .isEqualTo(now);
+            assertThat(persistedEntity.getDateModified())
+                    .isNotEqualTo(fileCopy.getDateModified())
+                    .isEqualTo(now);
+        }
+
+        private FileCopyJpaEntity getPersistedEntity(FileCopyId id) {
+            return entityManager.find(FileCopyJpaEntity.class, id.value());
         }
     }
 }

--- a/backend/src/test/java/dev/codesoapbox/backity/core/game/infrastructure/adapters/driven/persistence/jpa/GameJpaRepositoryIT.java
+++ b/backend/src/test/java/dev/codesoapbox/backity/core/game/infrastructure/adapters/driven/persistence/jpa/GameJpaRepositoryIT.java
@@ -8,12 +8,16 @@ import dev.codesoapbox.backity.core.game.domain.exceptions.GameNotFoundException
 import dev.codesoapbox.backity.shared.domain.Page;
 import dev.codesoapbox.backity.shared.domain.Pagination;
 import dev.codesoapbox.backity.testing.jpa.annotations.MultiDatabaseRepositoryTest;
+import dev.codesoapbox.backity.testing.jpa.extensions.EntityAuditControl;
+import dev.codesoapbox.backity.testing.time.FakeClock;
 import org.hibernate.exception.ConstraintViolationException;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.jpa.test.autoconfigure.TestEntityManager;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Supplier;
@@ -25,6 +29,8 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 @Transactional // Required by @JpaRepositoryTest
 abstract class GameJpaRepositoryIT {
 
+    private final Assertions assertThat = new Assertions();
+
     @Autowired
     private GameJpaRepository repository;
 
@@ -33,6 +39,15 @@ abstract class GameJpaRepositoryIT {
 
     @Autowired
     private GameJpaEntityMapper entityMapper;
+
+    @Autowired
+    private FakeClock clock;
+
+    @SuppressWarnings("JUnitMalformedDeclaration")
+    @BeforeEach
+    void setUp(EntityAuditControl entityAuditControl) {
+        entityAuditControl.disable();
+    }
 
     @Test
     void saveShouldPersistNew() {
@@ -48,10 +63,26 @@ abstract class GameJpaRepositoryIT {
         assertWasPersisted(game);
     }
 
+    private void assertWasPersisted(Game game) {
+        GameJpaEntity persistedEntity = entityManager.find(GameJpaEntity.class, game.getId().value());
+        Game persistedGame = entityMapper.toDomain(persistedEntity);
+        assertSame(persistedGame, game);
+    }
+
+    private void assertSame(Game actual, Game expected) {
+        assertThat(actual)
+                .satisfies(it -> {
+                    assertThat(it.getDateCreated()).isNotNull();
+                    assertThat(it.getDateModified()).isNotNull();
+                })
+                .usingRecursiveComparison()
+                .isEqualTo(expected);
+    }
+
     @Test
     void shouldNotSaveGivenGameWithTitleAlreadyExists() {
-        populateDatabase(List.of(GAMES.GAME_1.get()));
-        GameTitle existingTitle = GAMES.GAME_1.get().getTitle();
+        persistGames(List.of(SampleGames.GAME_1.get()));
+        GameTitle existingTitle = SampleGames.GAME_1.get().getTitle();
         Game game = TestGame.anyBuilder()
                 .withId(GameId.newInstance())
                 .withTitle(existingTitle)
@@ -63,7 +94,7 @@ abstract class GameJpaRepositoryIT {
                 .isInstanceOf(ConstraintViolationException.class);
     }
 
-    private void populateDatabase(List<Game> games) {
+    private void persistGames(List<Game> games) {
         for (Game game : games) {
             entityManager.persist(entityMapper.toEntity(game));
         }
@@ -73,8 +104,8 @@ abstract class GameJpaRepositoryIT {
 
     @Test
     void saveShouldModifyExisting() {
-        populateDatabase(List.of(GAMES.GAME_1.get()));
-        Game game = GAMES.GAME_1.get();
+        persistGames(List.of(SampleGames.GAME_1.get()));
+        Game game = SampleGames.GAME_1.get();
         game.setTitle(new GameTitle("New Title"));
 
         Game result = repository.save(game);
@@ -84,16 +115,22 @@ abstract class GameJpaRepositoryIT {
         assertWasPersisted(game);
     }
 
-    private void assertWasPersisted(Game game) {
-        GameJpaEntity persistedEntity = entityManager.find(GameJpaEntity.class, game.getId().value());
-        Game persistedGame = entityMapper.toDomain(persistedEntity);
-        assertSame(persistedGame, game);
+    @SuppressWarnings("JUnitMalformedDeclaration")
+    @Test
+    void saveShouldUpdateDates(EntityAuditControl entityAuditControl) {
+        entityAuditControl.enable();
+        Game game = SampleGames.GAME_1.get();
+
+        repository.save(game);
+        entityManager.flush();
+
+        assertThat.datesWereUpdatedByAuditingHandler(game);
     }
 
     @Test
     void shouldFindById() {
-        populateDatabase(GAMES.getAll());
-        Game game = GAMES.GAME_1.get();
+        persistGames(SampleGames.getAll());
+        Game game = SampleGames.GAME_1.get();
 
         Optional<Game> maybeFoundGame = repository.findById(game.getId());
 
@@ -101,21 +138,10 @@ abstract class GameJpaRepositoryIT {
         assertSame(maybeFoundGame.get(), game);
     }
 
-    private void assertSame(Game actual, Game expected) {
-        assertThat(actual)
-                .satisfies(it -> {
-                    assertThat(it.getDateCreated()).isNotNull();
-                    assertThat(it.getDateModified()).isNotNull();
-                })
-                .usingRecursiveComparison()
-                .ignoringFields("dateCreated", "dateModified")
-                .isEqualTo(expected);
-    }
-
     @Test
     void shouldGetById() {
-        populateDatabase(GAMES.getAll());
-        Game game = GAMES.GAME_1.get();
+        persistGames(SampleGames.getAll());
+        Game game = SampleGames.GAME_1.get();
 
         Game maybeFoundGame = repository.getById(game.getId());
 
@@ -132,8 +158,8 @@ abstract class GameJpaRepositoryIT {
 
     @Test
     void shouldFindByTitle() {
-        populateDatabase(GAMES.getAll());
-        var game = GAMES.GAME_1.get();
+        persistGames(SampleGames.getAll());
+        var game = SampleGames.GAME_1.get();
 
         Optional<Game> maybeFoundGame = repository.findByTitle(game.getTitle());
 
@@ -143,11 +169,11 @@ abstract class GameJpaRepositoryIT {
 
     @Test
     void shouldFindAllPaginated() {
-        populateDatabase(GAMES.getAll());
+        persistGames(SampleGames.getAll());
         Pagination pageable = new Pagination(0, 5);
         Page<Game> result = repository.findAll(pageable);
 
-        Page<Game> expectedResult = new Page<>(List.of(GAMES.GAME_1.get(), GAMES.GAME_2.get()),
+        Page<Game> expectedResult = new Page<>(List.of(SampleGames.GAME_1.get(), SampleGames.GAME_2.get()),
                 1, 2,
                 new Pagination(0, 5));
         assertThat(result).usingRecursiveComparison()
@@ -159,18 +185,17 @@ abstract class GameJpaRepositoryIT {
 
     @Test
     void shouldFindAllById() {
-        populateDatabase(GAMES.getAll());
-        Game game = GAMES.GAME_1.get();
+        persistGames(SampleGames.getAll());
+        Game game = SampleGames.GAME_1.get();
 
         List<Game> result = repository.findAllByIdIn(List.of(game.getId()));
 
         List<Game> expectedResult = List.of(game);
         assertThat(result).usingRecursiveComparison()
-                .ignoringFields("dateCreated", "dateModified")
                 .isEqualTo(expectedResult);
     }
 
-    private static class GAMES {
+    private static class SampleGames {
 
         public static final Supplier<Game> GAME_1 = () -> TestGame.anyBuilder()
                 .withId(new GameId("5bdd248a-c3aa-487a-8479-0bfdb32f7ae5"))
@@ -184,6 +209,24 @@ abstract class GameJpaRepositoryIT {
 
         public static List<Game> getAll() {
             return List.of(GAME_1.get(), GAME_2.get());
+        }
+    }
+
+    private class Assertions {
+
+        void datesWereUpdatedByAuditingHandler(Game game) {
+            LocalDateTime now = LocalDateTime.now(clock);
+            GameJpaEntity persistedEntity = getPersistedEntity(game.getId());
+            assertThat(persistedEntity.getDateCreated())
+                    .isNotEqualTo(game.getDateCreated())
+                    .isEqualTo(now);
+            assertThat(persistedEntity.getDateModified())
+                    .isNotEqualTo(game.getDateModified())
+                    .isEqualTo(now);
+        }
+
+        private GameJpaEntity getPersistedEntity(GameId id) {
+            return entityManager.find(GameJpaEntity.class, id.value());
         }
     }
 }

--- a/backend/src/test/java/dev/codesoapbox/backity/core/game/infrastructure/adapters/driven/persistence/jpa/readmodel/GameWithFileCopiesReadModelJpaRepositoryIT.java
+++ b/backend/src/test/java/dev/codesoapbox/backity/core/game/infrastructure/adapters/driven/persistence/jpa/readmodel/GameWithFileCopiesReadModelJpaRepositoryIT.java
@@ -19,6 +19,7 @@ import dev.codesoapbox.backity.core.sourcefile.infrastructure.adapters.driven.pe
 import dev.codesoapbox.backity.shared.domain.Page;
 import dev.codesoapbox.backity.shared.domain.Pagination;
 import dev.codesoapbox.backity.testing.jpa.annotations.MultiDatabaseRepositoryTest;
+import dev.codesoapbox.backity.testing.jpa.extensions.EntityAuditControl;
 import dev.codesoapbox.backity.testing.time.config.FakeTimeBeanConfig;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -29,7 +30,6 @@ import org.mapstruct.factory.Mappers;
 import org.mockito.ArgumentCaptor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.jpa.test.autoconfigure.TestEntityManager;
-import org.springframework.data.auditing.AuditingHandler;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
@@ -41,8 +41,6 @@ import java.util.function.Supplier;
 import static java.util.Collections.emptyList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.when;
 
 @MultiDatabaseRepositoryTest
@@ -121,20 +119,14 @@ abstract class GameWithFileCopiesReadModelJpaRepositoryIT {
     @Autowired
     private GameWithFilesCopiesReadModelJpaEntityMapper entityMapperSpy;
 
-    @Autowired
-    private AuditingHandler auditingHandlerSpy;
-
+    @SuppressWarnings("JUnitMalformedDeclaration")
     @BeforeEach
-    void setUp() {
+    void setUp(EntityAuditControl entityAuditControl) {
+        entityAuditControl.disable();
         populateDatabase();
     }
 
     private void populateDatabase() {
-        // Prevent Spring Data JPA auditing from overwriting preset @CreatedDate/@LastModifiedDate values
-        // during test data setup:
-        doAnswer(inv -> inv)
-                .when(auditingHandlerSpy).markCreated(any());
-
         for (Game game : ExistingGames.getAll()) {
             entityManager.persist(ExistingGames.MAPPER.toEntity(game));
         }
@@ -249,7 +241,8 @@ abstract class GameWithFileCopiesReadModelJpaRepositoryIT {
 
     private List<GameWithFileCopiesReadModelJpaEntity> interceptFetchedEntities() {
         List<GameWithFileCopiesReadModelJpaEntity> entities = new ArrayList<>();
-        var captor = ArgumentCaptor.forClass(GameWithFileCopiesReadModelJpaEntity.class);
+        ArgumentCaptor<GameWithFileCopiesReadModelJpaEntity> captor =
+                ArgumentCaptor.forClass(GameWithFileCopiesReadModelJpaEntity.class);
         when(entityMapperSpy.toReadModel(captor.capture()))
                 .thenAnswer(_ -> {
                     entities.add(captor.getValue());

--- a/backend/src/test/java/dev/codesoapbox/backity/core/sourcefile/infrastructure/adapters/driven/persistence/jpa/SourceFileJpaRepositoryIT.java
+++ b/backend/src/test/java/dev/codesoapbox/backity/core/sourcefile/infrastructure/adapters/driven/persistence/jpa/SourceFileJpaRepositoryIT.java
@@ -6,8 +6,8 @@ import dev.codesoapbox.backity.core.game.domain.GameTitle;
 import dev.codesoapbox.backity.core.game.infrastructure.adapters.driven.persistence.jpa.GameJpaEntityMapper;
 import dev.codesoapbox.backity.core.sourcefile.domain.*;
 import dev.codesoapbox.backity.core.sourcefile.domain.exceptions.SourceFileNotFoundException;
-import dev.codesoapbox.backity.shared.domain.DomainEventPublisher;
 import dev.codesoapbox.backity.testing.jpa.annotations.MultiDatabaseRepositoryTest;
+import dev.codesoapbox.backity.testing.jpa.extensions.EntityAuditControl;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -17,6 +17,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.jpa.test.autoconfigure.TestEntityManager;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.Clock;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Supplier;
@@ -29,8 +31,10 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 @Transactional // Required by @JpaRepositoryTest
 abstract class SourceFileJpaRepositoryIT {
 
+    private final Assertions assertThat = new Assertions();
+
     @Autowired
-    protected SourceFileJpaRepository sourceFileJpaRepository;
+    protected SourceFileJpaRepository repository;
 
     @Autowired
     protected TestEntityManager entityManager;
@@ -39,34 +43,28 @@ abstract class SourceFileJpaRepositoryIT {
     protected SourceFileJpaEntityMapper entityMapper;
 
     @Autowired
-    protected DomainEventPublisher domainEventPublisher;
+    protected Clock clock;
 
+    @SuppressWarnings("JUnitMalformedDeclaration")
     @BeforeEach
-    void setUp() {
-        persistExistingDependencies();
-        entityManager.flush();
-        entityManager.clear();
+    void setUp(EntityAuditControl entityAuditControl) {
+        entityAuditControl.disable();
     }
 
-    private void persistExistingDependencies() {
-        for (Game game : EXISTING_GAMES.getAll()) {
-            entityManager.persist(EXISTING_GAMES.MAPPER.toEntity(game));
-        }
-    }
-
-    private void populateDatabase(List<SourceFile> sourceFiles) {
-        for (SourceFile sourceFile : sourceFiles) {
-            entityManager.persist(entityMapper.toEntity(sourceFile));
+    private void persistSampleDependencies() {
+        for (Game game : SampleGames.getAll()) {
+            entityManager.persist(SampleGames.MAPPER.toEntity(game));
         }
         entityManager.flush();
         entityManager.clear();
     }
 
     @Test
-    void shouldSave() {
+    void saveShouldPersistNew() {
+        persistSampleDependencies();
         SourceFile newSourceFile = TestSourceFile.gog();
 
-        SourceFile result = sourceFileJpaRepository.save(newSourceFile);
+        SourceFile result = repository.save(newSourceFile);
         entityManager.flush();
 
         assertEquals(result, newSourceFile);
@@ -76,7 +74,6 @@ abstract class SourceFileJpaRepositoryIT {
     private void assertEquals(SourceFile result, SourceFile expected) {
         assertThat(result)
                 .usingRecursiveComparison()
-                .ignoringFields("dateCreated", "dateModified")
                 .isEqualTo(expected);
     }
 
@@ -87,41 +84,74 @@ abstract class SourceFileJpaRepositoryIT {
                 .extracting(entity -> entityMapper.toDomain(entity))
                 .hasNoNullFieldsOrProperties()
                 .usingRecursiveComparison()
-                .ignoringFields("dateCreated", "dateModified")
                 .isEqualTo(newSourceFile);
-        assertThat(persistedEntity.getDateCreated()).isNotNull();
-        assertThat(persistedEntity.getDateModified()).isNotNull();
+    }
+
+    @Test
+    void saveShouldModifyExisting() {
+        persistSampleDependencies();
+        SourceFile sourceFile = SampleSourceFiles.GOG_SOURCE_FILE_1_FOR_GAME_1.get();
+        persistSourceFiles(List.of(sourceFile));
+        sourceFile.setFileTitle(new FileTitle("differentFileTitle"));
+
+        repository.save(sourceFile);
+        entityManager.flush();
+
+        assertWasPersisted(sourceFile);
+    }
+
+    private void persistSourceFiles(List<SourceFile> sourceFiles) {
+        for (SourceFile sourceFile : sourceFiles) {
+            entityManager.persist(entityMapper.toEntity(sourceFile));
+        }
+        entityManager.flush();
+        entityManager.clear();
+    }
+
+    @SuppressWarnings("JUnitMalformedDeclaration")
+    @Test
+    void saveShouldUpdateDates(EntityAuditControl entityAuditControl) {
+        persistSampleDependencies();
+        entityAuditControl.enable();
+        SourceFile sourceFile = SampleSourceFiles.GOG_SOURCE_FILE_1_FOR_GAME_1.get();
+
+        repository.save(sourceFile);
+        entityManager.flush();
+
+        assertThat.datesWereUpdatedByAuditingHandler(sourceFile);
     }
 
     @ParameterizedTest(name = "should return {1} for version={0}")
     @CsvSource(value = {"1.0.0,true", "fakeVersion,false"})
     void existsByUrlAndVersion(String versionValue, boolean shouldFind) {
-        populateDatabase(SOURCE_FILES.getAll());
+        persistSampleDependencies();
+        persistSourceFiles(SampleSourceFiles.getAll());
         var version = new FileVersion(versionValue);
         var url = new SourceFileUrl("/downlink/some_game/some_file");
-        boolean exists = sourceFileJpaRepository.existsByUrlAndVersion(url, version);
+        boolean exists = repository.existsByUrlAndVersion(url, version);
 
         assertThat(exists).isEqualTo(shouldFind);
     }
 
     @Test
     void shouldFindById() {
-        populateDatabase(SOURCE_FILES.getAll());
-        SourceFile expectedSourceFile = SOURCE_FILES.GOG_SOURCE_FILE_1_FOR_GAME_1.get();
+        persistSampleDependencies();
+        persistSourceFiles(SampleSourceFiles.getAll());
+        SourceFile expectedSourceFile = SampleSourceFiles.GOG_SOURCE_FILE_1_FOR_GAME_1.get();
 
-        Optional<SourceFile> result = sourceFileJpaRepository.findById(expectedSourceFile.getId());
+        Optional<SourceFile> result = repository.findById(expectedSourceFile.getId());
 
         assertThat(result).get().usingRecursiveComparison()
-                .ignoringFields("dateCreated", "dateModified")
                 .isEqualTo(expectedSourceFile);
     }
 
     @Test
     void shouldGetById() {
-        populateDatabase(SOURCE_FILES.getAll());
-        SourceFile expectedSourceFile = SOURCE_FILES.GOG_SOURCE_FILE_1_FOR_GAME_1.get();
+        persistSampleDependencies();
+        persistSourceFiles(SampleSourceFiles.getAll());
+        SourceFile expectedSourceFile = SampleSourceFiles.GOG_SOURCE_FILE_1_FOR_GAME_1.get();
 
-        SourceFile result = sourceFileJpaRepository.getById(expectedSourceFile.getId());
+        SourceFile result = repository.getById(expectedSourceFile.getId());
 
         assertEquals(result, expectedSourceFile);
     }
@@ -130,45 +160,47 @@ abstract class SourceFileJpaRepositoryIT {
     void getByIdShouldThrowGivenNotFound() {
         var nonexistentId = new SourceFileId("59e37c43-dda7-4c5f-87a3-c380ebb5f8ea");
 
-        assertThatThrownBy(() -> sourceFileJpaRepository.getById(nonexistentId))
+        assertThatThrownBy(() -> repository.getById(nonexistentId))
                 .isInstanceOf(SourceFileNotFoundException.class);
     }
 
     @Test
     void shouldFindByGameId() {
-        populateDatabase(SOURCE_FILES.getAll());
-        List<SourceFile> result = sourceFileJpaRepository.findAllByGameId(EXISTING_GAMES.GAME_1.getId());
+        persistSampleDependencies();
+        persistSourceFiles(SampleSourceFiles.getAll());
+        List<SourceFile> result = repository.findAllByGameId(SampleGames.GAME_1.getId());
 
         assertThat(result).containsExactlyInAnyOrder(
-                SOURCE_FILES.GOG_SOURCE_FILE_1_FOR_GAME_1.get(),
-                SOURCE_FILES.GOG_SOURCE_FILE_2_FOR_GAME_1.get()
+                SampleSourceFiles.GOG_SOURCE_FILE_1_FOR_GAME_1.get(),
+                SampleSourceFiles.GOG_SOURCE_FILE_2_FOR_GAME_1.get()
         );
     }
 
     @Test
     void shouldFindAllById() {
-        populateDatabase(SOURCE_FILES.getAll());
-        SourceFile expectedSourceFile = SOURCE_FILES.GOG_SOURCE_FILE_1_FOR_GAME_1.get();
+        persistSampleDependencies();
+        persistSourceFiles(SampleSourceFiles.getAll());
+        SourceFile expectedSourceFile = SampleSourceFiles.GOG_SOURCE_FILE_1_FOR_GAME_1.get();
 
-        List<SourceFile> result = sourceFileJpaRepository.findAllByIdIn(List.of(expectedSourceFile.getId()));
+        List<SourceFile> result = repository.findAllByIdIn(List.of(expectedSourceFile.getId()));
 
         assertThat(result).usingRecursiveComparison()
-                .ignoringFields("dateCreated", "dateModified")
                 .isEqualTo(List.of(expectedSourceFile));
     }
 
     @Test
     void shouldDeleteById() {
-        SourceFile sourceFile = SOURCE_FILES.GOG_SOURCE_FILE_1_FOR_GAME_1.get();
-        populateDatabase(List.of(sourceFile));
+        persistSampleDependencies();
+        SourceFile sourceFile = SampleSourceFiles.GOG_SOURCE_FILE_1_FOR_GAME_1.get();
+        persistSourceFiles(List.of(sourceFile));
 
-        sourceFileJpaRepository.deleteById(sourceFile.getId());
+        repository.deleteById(sourceFile.getId());
 
         var foundEntity = entityManager.find(SourceFileJpaEntity.class, sourceFile.getId().value());
         assertThat(foundEntity).isNull();
     }
 
-    private static class EXISTING_GAMES {
+    private static class SampleGames {
 
         public static final GameJpaEntityMapper MAPPER = Mappers.getMapper(GameJpaEntityMapper.class);
 
@@ -187,28 +219,46 @@ abstract class SourceFileJpaRepositoryIT {
         }
     }
 
-    private static class SOURCE_FILES {
+    private static class SampleSourceFiles {
 
         public static final Supplier<SourceFile> GOG_SOURCE_FILE_1_FOR_GAME_1 = () -> TestSourceFile.gogBuilder()
                 .id(new SourceFileId("acde26d7-33c7-42ee-be16-bca91a604b48"))
-                .gameId(EXISTING_GAMES.GAME_1.getId())
+                .gameId(SampleGames.GAME_1.getId())
                 .build();
 
         public static final Supplier<SourceFile> GOG_SOURCE_FILE_2_FOR_GAME_1 = () -> TestSourceFile.gogBuilder()
                 .id(new SourceFileId("a6adc122-df20-4e2c-a975-7d4af7104704"))
-                .gameId(EXISTING_GAMES.GAME_1.getId())
+                .gameId(SampleGames.GAME_1.getId())
                 .build();
 
         public static final Supplier<SourceFile> GOG_SOURCE_FILE_1_FOR_GAME_2 = () -> TestSourceFile.gogBuilder()
                 .id(new SourceFileId("3d65af79-a558-4f23-88bd-3c04e977e63f"))
-                .gameId(EXISTING_GAMES.GAME_2.getId())
+                .gameId(SampleGames.GAME_2.getId())
                 .build();
 
         public static List<SourceFile> getAll() {
             return List.of(
-                    SOURCE_FILES.GOG_SOURCE_FILE_1_FOR_GAME_1.get(), SOURCE_FILES.GOG_SOURCE_FILE_2_FOR_GAME_1.get(),
-                    SOURCE_FILES.GOG_SOURCE_FILE_1_FOR_GAME_2.get()
+                    SampleSourceFiles.GOG_SOURCE_FILE_1_FOR_GAME_1.get(), SampleSourceFiles.GOG_SOURCE_FILE_2_FOR_GAME_1.get(),
+                    SampleSourceFiles.GOG_SOURCE_FILE_1_FOR_GAME_2.get()
             );
+        }
+    }
+
+    private class Assertions {
+
+        void datesWereUpdatedByAuditingHandler(SourceFile sourceFile) {
+            LocalDateTime now = LocalDateTime.now(clock);
+            SourceFileJpaEntity persistedEntity = getPersistedEntity(sourceFile.getId());
+            assertThat(persistedEntity.getDateCreated())
+                    .isNotEqualTo(sourceFile.getDateCreated())
+                    .isEqualTo(now);
+            assertThat(persistedEntity.getDateModified())
+                    .isNotEqualTo(sourceFile.getDateModified())
+                    .isEqualTo(now);
+        }
+
+        private SourceFileJpaEntity getPersistedEntity(SourceFileId id) {
+            return entityManager.find(SourceFileJpaEntity.class, id.value());
         }
     }
 }

--- a/backend/src/test/java/dev/codesoapbox/backity/testing/jpa/annotations/JpaRepositoryTest.java
+++ b/backend/src/test/java/dev/codesoapbox/backity/testing/jpa/annotations/JpaRepositoryTest.java
@@ -4,13 +4,14 @@ import dev.codesoapbox.backity.BackityApplication;
 import dev.codesoapbox.backity.core.game.infrastructure.adapters.driven.persistence.jpa.readmodel.GameWithFilesCopiesReadModelJpaEntityMapper;
 import dev.codesoapbox.backity.shared.domain.DomainEventPublisher;
 import dev.codesoapbox.backity.shared.infrastructure.config.slices.JpaRepositoryBeanConfiguration;
+import dev.codesoapbox.backity.testing.jpa.extensions.EntityAuditControlExtension;
 import dev.codesoapbox.backity.testing.time.config.FakeTimeBeanConfig;
 import dev.codesoapbox.backity.testing.time.config.ResetClockTestExecutionListener;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.FilterType;
 import org.springframework.context.annotation.Import;
-import org.springframework.data.auditing.AuditingHandler;
 import org.springframework.test.context.TestExecutionListeners;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
@@ -60,7 +61,7 @@ import java.lang.annotation.Target;
 })
 @MockitoSpyBean(types = {
         GameWithFilesCopiesReadModelJpaEntityMapper.class,
-        AuditingHandler.class
 })
+@ExtendWith(EntityAuditControlExtension.class)
 public @interface JpaRepositoryTest {
 }

--- a/backend/src/test/java/dev/codesoapbox/backity/testing/jpa/extensions/EntityAuditControl.java
+++ b/backend/src/test/java/dev/codesoapbox/backity/testing/jpa/extensions/EntityAuditControl.java
@@ -1,0 +1,28 @@
+package dev.codesoapbox.backity.testing.jpa.extensions;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.auditing.AuditingHandler;
+
+/// Controls whether JPA entity auditing is applied during persistence operations.
+///
+/// By default, Spring Data automatically populates fields annotated with
+/// [CreatedDate] and [LastModifiedDate] on every save.
+/// This makes it impossible to persist entities with custom timestamps, which is
+/// often necessary when setting up test fixtures that represent historical data.
+///
+/// This class allows auditing to be temporarily disabled so that custom date values are preserved during persistence.
+@RequiredArgsConstructor
+public class EntityAuditControl {
+
+    private final AuditingHandler auditingHandler;
+
+    public void disable() {
+        auditingHandler.setDateTimeForNow(false);
+    }
+
+    public void enable() {
+        auditingHandler.setDateTimeForNow(true);
+    }
+}

--- a/backend/src/test/java/dev/codesoapbox/backity/testing/jpa/extensions/EntityAuditControlExtension.java
+++ b/backend/src/test/java/dev/codesoapbox/backity/testing/jpa/extensions/EntityAuditControlExtension.java
@@ -1,0 +1,40 @@
+package dev.codesoapbox.backity.testing.jpa.extensions;
+
+import org.junit.jupiter.api.extension.*;
+import org.springframework.context.ApplicationContext;
+import org.springframework.data.auditing.AuditingHandler;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+public class EntityAuditControlExtension implements BeforeEachCallback, AfterEachCallback, ParameterResolver {
+
+    private static final String STORE_KEY = "entityAuditControl";
+
+    private ExtensionContext.Store getStore(ExtensionContext context) {
+        return context.getStore(
+                ExtensionContext.Namespace.create(EntityAuditControlExtension.class, context.getUniqueId()));
+    }
+
+    @Override
+    public void beforeEach(ExtensionContext context) {
+        ApplicationContext appContext = SpringExtension.getApplicationContext(context);
+        AuditingHandler auditingHandler = appContext.getBean(AuditingHandler.class);
+        getStore(context).put(STORE_KEY, new EntityAuditControl(auditingHandler));
+    }
+
+    @Override
+    public void afterEach(ExtensionContext context) {
+        getStore(context).get(STORE_KEY, EntityAuditControl.class).enable();
+    }
+
+    @Override
+    public boolean supportsParameter(ParameterContext parameterContext, ExtensionContext extensionContext)
+            throws ParameterResolutionException {
+        return EntityAuditControl.class.equals(parameterContext.getParameter().getType());
+    }
+
+    @Override
+    public Object resolveParameter(ParameterContext parameterContext, ExtensionContext extensionContext)
+            throws ParameterResolutionException {
+        return getStore(extensionContext).get(STORE_KEY, EntityAuditControl.class);
+    }
+}

--- a/backend/src/test/java/dev/codesoapbox/backity/testing/time/config/FakeTimeBeanConfig.java
+++ b/backend/src/test/java/dev/codesoapbox/backity/testing/time/config/FakeTimeBeanConfig.java
@@ -1,13 +1,15 @@
 package dev.codesoapbox.backity.testing.time.config;
 
 import dev.codesoapbox.backity.testing.time.FakeClock;
-import jakarta.validation.ClockProvider;
-import lombok.RequiredArgsConstructor;
 import org.springframework.boot.validation.autoconfigure.ValidationConfigurationCustomizer;
 import org.springframework.context.annotation.Bean;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.auditing.DateTimeProvider;
 
 import java.time.Clock;
 import java.time.LocalDateTime;
+import java.util.Optional;
 
 public class FakeTimeBeanConfig {
 
@@ -17,27 +19,19 @@ public class FakeTimeBeanConfig {
     public static final FakeClock CLOCK = FakeClock.at(DEFAULT_NOW);
 
     @Bean
-    FakeClock fixedClock() {
+    FakeClock fakeClock() {
         return CLOCK;
     }
 
-    /**
-     * Freezes time for bean validation, so that annotations like {@code @FutureOrPresent} don't break in the future.
-     */
+    /// Provides time for bean validation
     @Bean
     ValidationConfigurationCustomizer validationConfigurationCustomizer(Clock clock) {
-        FakeClockProvider fixedClockProvider = new FakeClockProvider(clock);
-        return c -> c.clockProvider(fixedClockProvider);
+        return c -> c.clockProvider(() -> clock);
     }
 
-    @RequiredArgsConstructor
-    private static class FakeClockProvider implements ClockProvider {
-
-        private final Clock clock;
-
-        @Override
-        public Clock getClock() {
-            return clock;
-        }
+    /// Provides time for entity auditing ([CreatedDate], [LastModifiedDate])
+    @Bean
+    DateTimeProvider auditingDateTimeProvider(Clock clock) {
+        return () -> Optional.of(LocalDateTime.now(clock));
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Refactored JPA integration tests to centrally control auditing, added helpers to enable/disable auditing per test, standardized fixtures, and tightened timestamp assertions.
* **Chores**
  * Introduced a JUnit extension and audit-control utility for tests; updated test time configuration to provide a consistent date/time source.
* **Minor**
  * Added automatic string representation for the Game domain object.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/daniel-frak/backity/pull/412)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->