### PR TITLE
feat: Auto-mock dependencies based on `@Configuration` classes

### DIFF
--- a/backend/src/main/java/dev/codesoapbox/backity/core/game/infrastructure/adapters/driven/persistence/jpa/readmodel/GameWithFileCopiesReadModelJpaEntity.java
+++ b/backend/src/main/java/dev/codesoapbox/backity/core/game/infrastructure/adapters/driven/persistence/jpa/readmodel/GameWithFileCopiesReadModelJpaEntity.java
@@ -1,9 +1,6 @@
 package dev.codesoapbox.backity.core.game.infrastructure.adapters.driven.persistence.jpa.readmodel;
 
-import jakarta.persistence.Entity;
-import jakarta.persistence.Id;
-import jakarta.persistence.OneToMany;
-import jakarta.persistence.Table;
+import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -37,6 +34,7 @@ public class GameWithFileCopiesReadModelJpaEntity {
     private LocalDateTime dateCreated;
     private LocalDateTime dateModified;
 
+    @OrderBy("fileTitle ASC")
     @OneToMany(mappedBy = "gameId")
     private List<SourceFileWithCopiesReadModelJpaEntity> sourceFilesWithCopies = new ArrayList<>();
 }

--- a/backend/src/main/java/dev/codesoapbox/backity/core/game/infrastructure/adapters/driven/persistence/jpa/readmodel/SourceFileWithCopiesReadModelJpaEntity.java
+++ b/backend/src/main/java/dev/codesoapbox/backity/core/game/infrastructure/adapters/driven/persistence/jpa/readmodel/SourceFileWithCopiesReadModelJpaEntity.java
@@ -69,6 +69,7 @@ public class SourceFileWithCopiesReadModelJpaEntity {
     @Column(nullable = false)
     private long sizeInBytes;
 
+    @OrderBy("dateCreated DESC")
     @OneToMany(mappedBy = "naturalId.sourceFileId")
     private List<FileCopyReadModelJpaEntity> fileCopies = new ArrayList<>();
 }

--- a/backend/src/test/java/dev/codesoapbox/backity/testing/http/annotations/ControllerTest.java
+++ b/backend/src/test/java/dev/codesoapbox/backity/testing/http/annotations/ControllerTest.java
@@ -1,19 +1,9 @@
 package dev.codesoapbox.backity.testing.http.annotations;
 
 import dev.codesoapbox.backity.BackityApplication;
-import dev.codesoapbox.backity.core.backuptarget.application.*;
-import dev.codesoapbox.backity.core.discovery.application.GameContentDiscoveryService;
-import dev.codesoapbox.backity.core.discovery.application.usecases.GetGameContentDiscoveryOverviewsUseCase;
-import dev.codesoapbox.backity.core.discovery.application.usecases.StartGameContentDiscoveryUseCase;
-import dev.codesoapbox.backity.core.discovery.application.usecases.StopGameContentDiscoveryUseCase;
-import dev.codesoapbox.backity.core.filecopy.application.usecases.*;
-import dev.codesoapbox.backity.core.game.application.usecases.GetGamesWithFilesUseCase;
-import dev.codesoapbox.backity.core.sourcefile.domain.SourceFileRepository;
-import dev.codesoapbox.backity.core.storagesolution.application.GetStorageSolutionStatusesUseCase;
-import dev.codesoapbox.backity.gameproviders.gog.application.usecases.*;
-import dev.codesoapbox.backity.gameproviders.gog.domain.GogAuthService;
-import dev.codesoapbox.backity.gameproviders.gog.domain.GogLibraryService;
 import dev.codesoapbox.backity.shared.infrastructure.config.slices.ControllerBeanConfiguration;
+import dev.codesoapbox.backity.shared.infrastructure.config.slices.UseCaseBeanConfiguration;
+import dev.codesoapbox.backity.testing.mocking.MockBeansMatching;
 import dev.codesoapbox.backity.testing.time.config.FakeTimeBeanConfig;
 import dev.codesoapbox.backity.testing.time.config.ResetClockTestExecutionListener;
 import jakarta.persistence.EntityManager;
@@ -58,39 +48,18 @@ import java.lang.annotation.*;
         ),
         useDefaultFilters = false
 )
+@MockBeansMatching(
+        @ComponentScan(
+                basePackageClasses = BackityApplication.class,
+                includeFilters = @ComponentScan.Filter(
+                        type = FilterType.ANNOTATION,
+                        classes = UseCaseBeanConfiguration.class
+                ),
+                useDefaultFilters = false
+        )
+)
 @MockitoBean(types = {
-        // Common
-        EntityManager.class,
-
-        // Specific
-        SourceFileRepository.class,
-        GameContentDiscoveryService.class,
-        GogAuthService.class,
-        GogLibraryService.class,
-
-        // Use cases
-        GetGamesWithFilesUseCase.class,
-        StartGameContentDiscoveryUseCase.class,
-        StopGameContentDiscoveryUseCase.class,
-        GetGameContentDiscoveryOverviewsUseCase.class,
-        EnqueueFileCopyUseCase.class,
-        CancelFileCopyUseCase.class,
-        DeleteFileCopyUseCase.class,
-        DownloadFileCopyUseCase.class,
-        GetFileCopyQueueUseCase.class,
-        GetGogConfigUseCase.class,
-        AuthenticateGogUseCase.class,
-        CheckGogAuthenticationUseCase.class,
-        RefreshGogAccessTokenUseCase.class,
-        LogOutOfGogUseCase.class,
-        GetGogLibrarySizeUseCase.class,
-        GetGogGameDetailsUseCase.class,
-        GetBackupTargetsUseCase.class,
-        GetLockedBackupTargetIdsUseCase.class,
-        AddBackupTargetUseCase.class,
-        EditBackupTargetUseCase.class,
-        DeleteBackupTargetUseCase.class,
-        GetStorageSolutionStatusesUseCase.class
+        EntityManager.class // Needed by H2DbController
 })
 public @interface ControllerTest {
 }

--- a/backend/src/test/java/dev/codesoapbox/backity/testing/jpa/annotations/JpaRepositoryTest.java
+++ b/backend/src/test/java/dev/codesoapbox/backity/testing/jpa/annotations/JpaRepositoryTest.java
@@ -1,9 +1,10 @@
 package dev.codesoapbox.backity.testing.jpa.annotations;
 
 import dev.codesoapbox.backity.BackityApplication;
-import dev.codesoapbox.backity.shared.domain.DomainEventPublisher;
 import dev.codesoapbox.backity.shared.infrastructure.config.slices.JpaRepositoryBeanConfiguration;
+import dev.codesoapbox.backity.shared.infrastructure.config.slices.SpringApplicationEventPublisherBeanConfiguration;
 import dev.codesoapbox.backity.testing.jpa.extensions.EntityAuditControlExtension;
+import dev.codesoapbox.backity.testing.mocking.MockBeansMatching;
 import dev.codesoapbox.backity.testing.time.config.FakeTimeBeanConfig;
 import dev.codesoapbox.backity.testing.time.config.ResetClockTestExecutionListener;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -13,7 +14,6 @@ import org.springframework.context.annotation.FilterType;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.TestExecutionListeners;
 import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
@@ -57,9 +57,16 @@ import java.lang.annotation.Target;
         ),
         useDefaultFilters = false
 )
-@MockitoBean(types = {
-        DomainEventPublisher.class
-})
+@MockBeansMatching(
+        @ComponentScan(
+                basePackageClasses = BackityApplication.class,
+                includeFilters = @ComponentScan.Filter(
+                        type = FilterType.ANNOTATION,
+                        classes = SpringApplicationEventPublisherBeanConfiguration.class
+                ),
+                useDefaultFilters = false
+        )
+)
 @ExtendWith(EntityAuditControlExtension.class)
 public @interface JpaRepositoryTest {
 }

--- a/backend/src/test/java/dev/codesoapbox/backity/testing/messaging/annotations/SpringApplicationListenerTest.java
+++ b/backend/src/test/java/dev/codesoapbox/backity/testing/messaging/annotations/SpringApplicationListenerTest.java
@@ -1,9 +1,10 @@
 package dev.codesoapbox.backity.testing.messaging.annotations;
 
 import dev.codesoapbox.backity.BackityApplication;
-import dev.codesoapbox.backity.core.backup.application.usecases.RecoverInterruptedFileBackupUseCase;
 import dev.codesoapbox.backity.shared.infrastructure.config.slices.SpringApplicationListenerBeanConfiguration;
+import dev.codesoapbox.backity.shared.infrastructure.config.slices.UseCaseBeanConfiguration;
 import dev.codesoapbox.backity.testing.messaging.extensions.ApplicationEventScenarioExtension;
+import dev.codesoapbox.backity.testing.mocking.MockBeansMatching;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.SmartInitializingSingleton;
 import org.springframework.boot.SpringApplication;
@@ -14,7 +15,6 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.FilterType;
 import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import java.lang.annotation.*;
@@ -28,9 +28,16 @@ import java.time.Duration;
 @ContextConfiguration(classes = {
         SpringApplicationListenerTest.TestContext.class
 })
-@MockitoBean(types = {
-        RecoverInterruptedFileBackupUseCase.class
-})
+@MockBeansMatching(
+        @ComponentScan(
+                basePackageClasses = BackityApplication.class,
+                includeFilters = @ComponentScan.Filter(
+                        type = FilterType.ANNOTATION,
+                        classes = UseCaseBeanConfiguration.class
+                ),
+                useDefaultFilters = false
+        )
+)
 @ExtendWith(ApplicationEventScenarioExtension.class)
 public @interface SpringApplicationListenerTest {
 

--- a/backend/src/test/java/dev/codesoapbox/backity/testing/messaging/annotations/SpringEventListenerTest.java
+++ b/backend/src/test/java/dev/codesoapbox/backity/testing/messaging/annotations/SpringEventListenerTest.java
@@ -1,11 +1,7 @@
 package dev.codesoapbox.backity.testing.messaging.annotations;
 
 import dev.codesoapbox.backity.BackityApplication;
-import dev.codesoapbox.backity.core.backup.application.eventhandlers.ClearProgressOnFileBackupFinishedEventHandler;
-import dev.codesoapbox.backity.core.backup.application.eventhandlers.MarkBackupRecoveryCompletedOnBackupRecoveryCompletedEventHandler;
-import dev.codesoapbox.backity.core.backup.application.eventhandlers.ProcessFileCopyQueueOnFileCopyEnqueuedEventHandler;
-import dev.codesoapbox.backity.core.backup.application.eventhandlers.SaveProgressToRepositoryOnFileCopyReplicationProgressChangedEventHandler;
-import dev.codesoapbox.backity.shared.application.eventhandlers.DomainEventForwardingHandler;
+import dev.codesoapbox.backity.shared.infrastructure.config.slices.DomainEventHandlerBeanConfiguration;
 import dev.codesoapbox.backity.shared.infrastructure.config.slices.SpringApplicationEventPublisherBeanConfiguration;
 import dev.codesoapbox.backity.shared.infrastructure.config.slices.SpringAsyncConfiguration;
 import dev.codesoapbox.backity.shared.infrastructure.config.slices.SpringEventListenerBeanConfiguration;
@@ -15,6 +11,7 @@ import dev.codesoapbox.backity.testing.messaging.extensions.InMemoryEventScenari
 import dev.codesoapbox.backity.testing.messaging.extensions.OutboxEventScenarioExtension;
 import dev.codesoapbox.backity.testing.messaging.outbox.CleanUpOutboxEventsAfterTestExtension;
 import dev.codesoapbox.backity.testing.messaging.outbox.OutboxEventScenario;
+import dev.codesoapbox.backity.testing.mocking.MockBeansMatching;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.boot.persistence.autoconfigure.EntityScan;
 import org.springframework.boot.test.context.TestConfiguration;
@@ -24,7 +21,6 @@ import org.springframework.modulith.events.config.EnablePersistentDomainEvents;
 import org.springframework.modulith.events.core.EventPublicationRepository;
 import org.springframework.modulith.events.jpa.updating.DefaultJpaEventPublication;
 import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.event.TransactionalEventListener;
 import tools.jackson.databind.json.JsonMapper;
@@ -72,16 +68,6 @@ import java.lang.annotation.*;
         // Otherwise will throw `This ResultSet is closed` PSQLException:
         "spring.modulith.events.republish-outstanding-events-on-restart=false"
 })
-@MockitoBean(types = {
-        ClearProgressOnFileBackupFinishedEventHandler.class,
-        MarkBackupRecoveryCompletedOnBackupRecoveryCompletedEventHandler.class,
-        SaveProgressToRepositoryOnFileCopyReplicationProgressChangedEventHandler.class,
-        ProcessFileCopyQueueOnFileCopyEnqueuedEventHandler.class,
-        DomainEventForwardingHandler.class
-})
-@ExtendWith(OutboxEventScenarioExtension.class)
-@ExtendWith(InMemoryEventScenarioExtension.class)
-@ExtendWith(CleanUpOutboxEventsAfterTestExtension.class)
 @PostgresRepositoryTest
 @ComponentScan(
         basePackageClasses = BackityApplication.class,
@@ -95,10 +81,23 @@ import java.lang.annotation.*;
         ),
         useDefaultFilters = false
 )
+@MockBeansMatching(
+        @ComponentScan(
+                basePackageClasses = BackityApplication.class,
+                includeFilters = @ComponentScan.Filter(
+                        type = FilterType.ANNOTATION,
+                        classes = DomainEventHandlerBeanConfiguration.class
+                ),
+                useDefaultFilters = false
+        )
+)
 @EntityScan(basePackageClasses = {
         BackityApplication.class,
         DefaultJpaEventPublication.class
 })
+@ExtendWith(OutboxEventScenarioExtension.class)
+@ExtendWith(InMemoryEventScenarioExtension.class)
+@ExtendWith(CleanUpOutboxEventsAfterTestExtension.class)
 public @interface SpringEventListenerTest {
 
     @TestConfiguration

--- a/backend/src/test/java/dev/codesoapbox/backity/testing/mocking/MockBeansContextCustomizer.java
+++ b/backend/src/test/java/dev/codesoapbox/backity/testing/mocking/MockBeansContextCustomizer.java
@@ -1,0 +1,174 @@
+package dev.codesoapbox.backity.testing.mocking;
+
+import lombok.SneakyThrows;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.AnnotatedBeanDefinition;
+import org.springframework.beans.factory.config.BeanDefinition;
+import org.springframework.beans.factory.support.DefaultListableBeanFactory;
+import org.springframework.beans.factory.support.RootBeanDefinition;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.context.annotation.*;
+import org.springframework.core.annotation.AnnotationAttributes;
+import org.springframework.core.annotation.MergedAnnotation;
+import org.springframework.core.env.Environment;
+import org.springframework.core.io.ResourceLoader;
+import org.springframework.test.context.ContextCustomizer;
+import org.springframework.test.context.MergedContextConfiguration;
+import org.springframework.test.context.bean.override.mockito.MockReset;
+import org.springframework.util.ClassUtils;
+
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.Objects;
+import java.util.Set;
+
+class MockBeansContextCustomizer implements ContextCustomizer {
+
+    private final AnnotationAttributes componentScanAttributes;
+
+    MockBeansContextCustomizer(ComponentScan componentScan) {
+        this.componentScanAttributes = MergedAnnotation.from(componentScan)
+                .asAnnotationAttributes(MergedAnnotation.Adapt.ANNOTATION_TO_MAP);
+    }
+
+    @Override
+    public void customizeContext(ConfigurableApplicationContext context, MergedContextConfiguration mergedConfig) {
+        DefaultListableBeanFactory targetBeanFactory = (DefaultListableBeanFactory) context.getBeanFactory();
+        DefaultListableBeanFactory mockCandidateBeanFactory =
+                discoverMockCandidateBeans(context.getEnvironment(), context);
+
+        int registeredMocks = 0;
+        for (String name : mockCandidateBeanFactory.getBeanDefinitionNames()) {
+            BeanDefinition beanDefinition = mockCandidateBeanFactory.getBeanDefinition(name);
+            if (!isMockTarget(beanDefinition)) {
+                continue;
+            }
+            Class<?> rawType = resolveBeanType(beanDefinition, targetBeanFactory.getBeanClassLoader());
+
+            RootBeanDefinition mock = createMockBeanDefinition(rawType);
+            targetBeanFactory.registerBeanDefinition(name, mock);
+            registeredMocks++;
+        }
+
+        validateAtLeastOneMockWasRegistered(registeredMocks);
+    }
+
+    private DefaultListableBeanFactory discoverMockCandidateBeans(
+            Environment environment, ResourceLoader resourceLoader) {
+        var registry = new DefaultListableBeanFactory();
+        registerTopLevelMockCandidateBeans(registry, environment, resourceLoader);
+        registerBeanMethodMockCandidateBeans(registry, environment, resourceLoader);
+
+        return registry;
+    }
+
+    /// Registers beans which are directly annotated using `@Component` and its derivatives
+    private void registerTopLevelMockCandidateBeans(
+            DefaultListableBeanFactory registry, Environment environment, ResourceLoader resourceLoader) {
+        ClassPathBeanDefinitionScanner scanner = createBeanDefinitionScanner(environment, resourceLoader, registry);
+        scanner.scan(getBasePackages(componentScanAttributes));
+    }
+
+    private ClassPathBeanDefinitionScanner createBeanDefinitionScanner(
+            Environment environment, ResourceLoader resourceLoader, DefaultListableBeanFactory registry) {
+        boolean useDefaultFilters = componentScanAttributes.getBoolean("useDefaultFilters");
+        var scanner = new ClassPathBeanDefinitionScanner(registry, useDefaultFilters, environment, resourceLoader);
+
+        for (AnnotationAttributes filter : componentScanAttributes.getAnnotationArray("includeFilters")) {
+            TypeFilterUtils.createTypeFiltersFor(filter, environment, resourceLoader, registry)
+                    .forEach(scanner::addIncludeFilter);
+        }
+        for (AnnotationAttributes filter : componentScanAttributes.getAnnotationArray("excludeFilters")) {
+            TypeFilterUtils.createTypeFiltersFor(filter, environment, resourceLoader, registry)
+                    .forEach(scanner::addExcludeFilter);
+        }
+
+        return scanner;
+    }
+
+    /// Registers beans which are defined in @Configuration classes
+    private void registerBeanMethodMockCandidateBeans(
+            DefaultListableBeanFactory registry, Environment environment, ResourceLoader resourceLoader) {
+        ConfigurationClassPostProcessor parser = createConfigurationClassPostProcessor(environment, resourceLoader);
+        parser.postProcessBeanDefinitionRegistry(registry);
+    }
+
+    private ConfigurationClassPostProcessor createConfigurationClassPostProcessor(
+            Environment environment, ResourceLoader resourceLoader) {
+        var parser = new ConfigurationClassPostProcessor();
+        parser.setEnvironment(environment);
+        parser.setResourceLoader(resourceLoader);
+        parser.setBeanClassLoader(Objects.requireNonNull(resourceLoader.getClassLoader()));
+
+        return parser;
+    }
+
+    private String[] getBasePackages(AnnotationAttributes attributes) {
+        Set<String> packages = new LinkedHashSet<>();
+        Collections.addAll(packages, attributes.getStringArray("basePackages"));
+        for (Class<?> type : attributes.getClassArray("basePackageClasses")) {
+            packages.add(ClassUtils.getPackageName(type));
+        }
+        return packages.toArray(String[]::new);
+    }
+
+    private boolean isMockTarget(BeanDefinition definition) {
+        if (definition.getRole() == BeanDefinition.ROLE_INFRASTRUCTURE) {
+            return false; // Drop Spring's own post-processors
+        }
+        if (!(definition instanceof AnnotatedBeanDefinition annotated)) {
+            return true; // Keep plain classes (individual beans)
+        }
+        return isBeanMethod(annotated) // Keep @Bean instances
+                || !hasBeanMethods(annotated); // Drop config classes
+    }
+
+    private boolean isBeanMethod(AnnotatedBeanDefinition annotated) {
+        return annotated.getFactoryMethodMetadata() != null;
+    }
+
+    private boolean hasBeanMethods(AnnotatedBeanDefinition definition) {
+        return !definition.getMetadata().getAnnotatedMethods(Bean.class.getName()).isEmpty();
+    }
+
+    @SneakyThrows
+    private Class<?> resolveBeanType(BeanDefinition definition, ClassLoader classLoader) {
+        String beanClassName = getBeanClassName(definition);
+        return ClassUtils.forName(beanClassName, classLoader);
+    }
+
+    @SuppressWarnings("DataFlowIssue") // getFactoryMethodMetadata() is always non-null for bean methods
+    private String getBeanClassName(BeanDefinition definition) {
+        if (definition instanceof AnnotatedBeanDefinition annotated && isBeanMethod(annotated)) {
+            return annotated.getFactoryMethodMetadata().getReturnTypeName();
+        }
+        return definition.getBeanClassName();
+    }
+
+    private RootBeanDefinition createMockBeanDefinition(Class<?> rawType) {
+        var mock = new RootBeanDefinition(rawType);
+        mock.setInstanceSupplier(() -> Mockito.mock(rawType, MockReset.withSettings(MockReset.AFTER)));
+
+        return mock;
+    }
+
+    private void validateAtLeastOneMockWasRegistered(int registeredMocks) {
+        if (registeredMocks == 0) {
+            throw new IllegalStateException("@%s matched no beans for the given @ComponentScan: %s"
+                    .formatted(MockBeansMatching.class.getSimpleName(), componentScanAttributes));
+        }
+    }
+
+    // Necessary for context caching
+    @Override
+    public boolean equals(Object other) {
+        return (other instanceof MockBeansContextCustomizer that)
+                && this.componentScanAttributes.equals(that.componentScanAttributes);
+    }
+
+    // Necessary for context caching
+    @Override
+    public int hashCode() {
+        return this.componentScanAttributes.hashCode();
+    }
+}

--- a/backend/src/test/java/dev/codesoapbox/backity/testing/mocking/MockBeansContextCustomizerFactory.java
+++ b/backend/src/test/java/dev/codesoapbox/backity/testing/mocking/MockBeansContextCustomizerFactory.java
@@ -1,0 +1,32 @@
+package dev.codesoapbox.backity.testing.mocking;
+
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.core.annotation.MergedAnnotation;
+import org.springframework.core.annotation.MergedAnnotations;
+import org.springframework.core.annotation.MergedAnnotations.SearchStrategy;
+import org.springframework.test.context.ContextConfigurationAttributes;
+import org.springframework.test.context.ContextCustomizer;
+import org.springframework.test.context.ContextCustomizerFactory;
+
+import java.util.List;
+
+class MockBeansContextCustomizerFactory implements ContextCustomizerFactory {
+
+    @Override
+    public ContextCustomizer createContextCustomizer(
+            Class<?> testClass, List<ContextConfigurationAttributes> configAttributes) {
+        MergedAnnotation<MockBeansMatching> annotation = findMockBeansMatchingAnnotation(testClass);
+
+        if (!annotation.isPresent()) {
+            return null;
+        }
+        ComponentScan componentScan = annotation.synthesize().value();
+        return new MockBeansContextCustomizer(componentScan);
+    }
+
+    private MergedAnnotation<MockBeansMatching> findMockBeansMatchingAnnotation(Class<?> testClass) {
+        return MergedAnnotations
+                .from(testClass, SearchStrategy.TYPE_HIERARCHY)
+                .get(MockBeansMatching.class);
+    }
+}

--- a/backend/src/test/java/dev/codesoapbox/backity/testing/mocking/MockBeansMatching.java
+++ b/backend/src/test/java/dev/codesoapbox/backity/testing/mocking/MockBeansMatching.java
@@ -1,0 +1,41 @@
+package dev.codesoapbox.backity.testing.mocking;
+
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.test.context.ContextCustomizerFactories;
+
+import java.lang.annotation.*;
+
+/// Registers Mockito mocks into a Spring test context for beans discovered via [ComponentScan].
+/// Works like a dynamic alternative to `@MockitoBean`.
+///
+/// For a matched configuration class, its `@Bean` methods are mocked;
+/// any matched non-configuration class is mocked directly.
+///
+/// Example:
+/// ```java
+/// @SpringJUnitConfig(Foo.class)
+/// @MockBeansMatching(
+///     @ComponentScan(
+///         basePackageClasses = MyApplication.class,
+///         includeFilters = @ComponentScan.Filter(
+///                 type = FilterType.ANNOTATION,
+///                 classes = BarSliceBeanConfiguration.class // BarBeanConfiguration is annotated with it
+///         ),
+///         useDefaultFilters = false
+///     )
+/// )
+/// class FooTest {
+///
+///     @Autowired Foo foo;
+///
+///     @Autowired Bar barMock; // declared as a real bean in BarBeanConfiguration
+/// }
+/// ```
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@ContextCustomizerFactories(MockBeansContextCustomizerFactory.class)
+public @interface MockBeansMatching {
+
+    ComponentScan value();
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Refactored test mock configuration to use component-scan-based matching instead of explicit bean enumeration, improving test maintainability and reducing boilerplate in test annotations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->