### PR TITLE
test: Write ArchUnit rule to force extracting mock stubbing into methods

### DIFF
--- a/backend/src/main/java/dev/codesoapbox/backity/gameproviders/gog/infrastructure/adapters/driven/api/spring/auth/GogAuthSpringService.java
+++ b/backend/src/main/java/dev/codesoapbox/backity/gameproviders/gog/infrastructure/adapters/driven/api/spring/auth/GogAuthSpringService.java
@@ -6,11 +6,14 @@ import dev.codesoapbox.backity.gameproviders.gog.domain.GogAuthService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
+import java.time.Clock;
 import java.time.LocalDateTime;
 
 @Slf4j
 @RequiredArgsConstructor
 public class GogAuthSpringService implements GogAuthService {
+
+    private final Clock clock;
 
     private String accessToken;
     private String refreshToken;
@@ -21,7 +24,7 @@ public class GogAuthSpringService implements GogAuthService {
 
     @Override
     public boolean isAuthenticated() {
-        return accessToken != null && expirationTime.isAfter(LocalDateTime.now());
+        return accessToken != null && expirationTime.isAfter(LocalDateTime.now(clock));
     }
 
     @Override
@@ -34,7 +37,7 @@ public class GogAuthSpringService implements GogAuthService {
         this.accessToken = response.getAccessToken();
         this.refreshToken = response.getRefreshToken();
         this.expiresInSeconds = response.getExpiresIn();
-        this.expirationTime = LocalDateTime.now().plusSeconds(response.getExpiresIn());
+        this.expirationTime = LocalDateTime.now(clock).plusSeconds(response.getExpiresIn());
     }
 
     @Override
@@ -50,14 +53,26 @@ public class GogAuthSpringService implements GogAuthService {
 
     @Override
     public String getAccessToken() {
+        validateIsAuthenticated();
+        validateNotExpired();
+
+        return accessToken;
+    }
+
+    private void validateIsAuthenticated() {
         if (accessToken == null) {
             throw new GogAuthException("You must authenticate before using the GOG API!");
         }
-        if (expirationTime.isBefore(LocalDateTime.now())) {
+    }
+
+    private void validateNotExpired() {
+        if (hasExpired(expirationTime)) {
             throw new GogAuthException("Access token expired!");
         }
+    }
 
-        return accessToken;
+    private boolean hasExpired(LocalDateTime expirationTime) {
+        return !expirationTime.isAfter(LocalDateTime.now(clock));
     }
 
     @Override
@@ -78,11 +93,15 @@ public class GogAuthSpringService implements GogAuthService {
             return;
         }
 
-        // Refresh token when it's halfway to expiring
-        if (expirationTime.minusSeconds(expiresInSeconds / 2).isBefore(LocalDateTime.now())) {
+        if (refreshTokenIsAtLeastHalfwayToExpiring()) {
             log.info("Refreshing access token...");
             refresh();
         }
+    }
+
+    private boolean refreshTokenIsAtLeastHalfwayToExpiring() {
+        LocalDateTime halfwayToActualExpiration = expirationTime.minusSeconds(expiresInSeconds / 2);
+        return hasExpired(halfwayToActualExpiration);
     }
 
     @Override

--- a/backend/src/main/java/dev/codesoapbox/backity/gameproviders/gog/infrastructure/config/GogServiceBeanConfig.java
+++ b/backend/src/main/java/dev/codesoapbox/backity/gameproviders/gog/infrastructure/config/GogServiceBeanConfig.java
@@ -37,8 +37,8 @@ public class GogServiceBeanConfig {
     }
 
     @Bean
-    GogAuthSpringService gogAuthService(GogAuthClient gogAuthClient) {
-        return new GogAuthSpringService(gogAuthClient);
+    GogAuthSpringService gogAuthService(Clock clock, GogAuthClient gogAuthClient) {
+        return new GogAuthSpringService(clock, gogAuthClient);
     }
 
     @Bean

--- a/backend/src/test/java/dev/codesoapbox/backity/archunit/rules/TestRules.java
+++ b/backend/src/test/java/dev/codesoapbox/backity/archunit/rules/TestRules.java
@@ -1,5 +1,6 @@
 package dev.codesoapbox.backity.archunit.rules;
 
+import com.tngtech.archunit.base.DescribedPredicate;
 import com.tngtech.archunit.core.domain.JavaClass;
 import com.tngtech.archunit.core.domain.JavaClasses;
 import com.tngtech.archunit.core.domain.JavaMethod;
@@ -18,7 +19,6 @@ import java.util.*;
 import java.util.stream.Collectors;
 
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.*;
-import static org.assertj.core.api.Fail.fail;
 
 @SuppressWarnings("unused")
 public class TestRules {
@@ -26,6 +26,13 @@ public class TestRules {
     static final List<String> TEST_SUFFIXES = List.of("Test", "IT");
     static final String SHOULD_GIVEN_PATTERN = "(?i)(?=.*should)(?!.*given.*should).*";
     static final String WHEN_OR_IF_PATTERN = ".*(?:^|[_\\W]|)[sS]hould(?:[_\\W]|[A-Z]).*?(?:[Ww]hen|[Ii]f)(?![a-z]).*";
+    static final Set<String> STUBBING_ENTRY_POINTS = Set.of(
+            "when",            // Mockito.when, LenientStubber.when
+            "given",           // BDDMockito.given
+            "doReturn", "doThrow", "doAnswer", "doNothing", "doCallRealMethod",
+            "lenient",         // Mockito.lenient().when(...)
+            "will", "willReturn", "willThrow", "willAnswer", "willDoNothing", "willCallRealMethod" // BDD style
+    );
 
     @ArchTest
     static final ArchRule ASSERTJ_SHOULD_BE_USED_INSTEAD_OF_JUNIT_ASSERTIONS =
@@ -83,6 +90,141 @@ public class TestRules {
                             Use 'given' to describe context instead of 'when' or 'if'.
                             """);
 
+    @ArchTest
+    static final ArchRule STUBBING_MUST_BE_EXTRACTED_TO_METHODS =
+            methods()
+                    .that(DescribedPredicate.describe("are test methods", method ->
+                            method.isAnnotatedWith(Test.class)
+                                    || method.isAnnotatedWith(ParameterizedTest.class)
+                                    || method.isAnnotatedWith(RepeatedTest.class)
+                                    || method.isAnnotatedWith(BeforeEach.class)
+                                    || method.isAnnotatedWith(BeforeAll.class)
+                                    || method.isAnnotatedWith(AfterEach.class)
+                                    || method.isAnnotatedWith(AfterAll.class)
+                    ))
+                    .should(new ArchCondition<>("have all mock stubbings extracted to methods") {
+                        @Override
+                        public void check(JavaMethod method, ConditionEvents events) {
+                            method.getMethodCallsFromSelf().stream()
+                                    .filter(call ->
+                                            call.getTargetOwner().getPackageName().startsWith("org.mockito"))
+                                    .filter(call -> STUBBING_ENTRY_POINTS.contains(call.getName()))
+                                    .forEach(call -> events.add(SimpleConditionEvent.violated(method,
+                                            "Method %s stubs directly via %s in %s".formatted(
+                                                    method.getFullName(), call.getName(), call.getSourceCodeLocation())
+                                    )));
+                        }
+                    })
+                    .because("""
+                            creating a higher-level DSL makes tests clearer and refactoring easier.
+                            
+                            Context:
+                            Tests often need to stub mock logic. However, when reading a test, it's not always clear \
+                            what the purpose of a given stubbing is. When mocking is complex or ubiquitous, \
+                            a test may become noisy and difficult to understand.
+                            
+                            Extracting stubbing to methods helps reduce the size of the test method and abstract away
+                            details which could otherwise overwhelm the reader. \
+                            Naming the method forces the author to articulate why the stub exists, \
+                            surfacing hidden assumptions.
+                            
+                            Arguably, some cases are simple enough that extracting stubbing methods may feel \
+                            excessive, such as when a REST controller interacts with a use case. \
+                            However, on the whole, this practice has a positive effect \
+                            on test readability and maintainability. \
+                            It would also be difficult to decide which exceptions to carve out without the rule \
+                            becoming hard to reason about. Therefore, the rule is enforced strictly.
+                            
+                            Positive consequences:
+                            - Complex tests will be easier to read and understand due to shorter method bodies \
+                            and descriptive helper method names.
+                            - Fewer places will need updating when a collaborator's API changes \
+                            (or if the mock is replaced with a different kind of test double), due to multiple tests \
+                            being able to use the same stubbing method.
+                            
+                            Neutral consequences:
+                            - Readers must navigate one extra method call to see the raw Mockito invocation.
+                            - Badly written method names may be more difficult to understand than a direct stubbing \
+                            would have been.
+                            
+                            Negative consequences:
+                            - For simple stubbings such as use case execution, extracting stubbing methods may feel \
+                            excessive and unnecessary.
+                            """);
+
+    private static final Map<String, List<JavaClass>> PRODUCTION_CLASSES_BY_SIMPLE_NAME;
+
+    @ArchTest
+    static final ArchRule TEST_CLASSES_SHOULD_RESIDE_IN_CORRECT_PACKAGE = classes()
+            .that(new DescribedPredicate<>("are top-level classes") {
+                @Override
+                public boolean test(JavaClass c) {
+                    return c.getEnclosingClass().isEmpty();
+                }
+            })
+            .and(new DescribedPredicate<>("are test classes") {
+                @Override
+                public boolean test(JavaClass c) {
+                    // Is a test class if a recognized suffix was successfully stripped
+                    return !stripTestSuffix(c.getSimpleName()).equals(c.getSimpleName());
+                }
+            })
+            .and(new DescribedPredicate<>("have a matching production class") {
+                @Override
+                public boolean test(JavaClass c) {
+                    return PRODUCTION_CLASSES_BY_SIMPLE_NAME.containsKey(stripTestSuffix(c.getSimpleName()));
+                }
+            })
+            .should(new ArchCondition<>("reside in the same package as their production class") {
+                @Override
+                public void check(JavaClass testClass, ConditionEvents events) {
+                    String testedSimpleName = stripTestSuffix(testClass.getSimpleName());
+                    List<JavaClass> candidates = PRODUCTION_CLASSES_BY_SIMPLE_NAME.get(testedSimpleName);
+
+                    boolean packageMatches = candidates.stream()
+                            .anyMatch(pc -> pc.getPackageName().equals(testClass.getPackageName()));
+
+                    if (!packageMatches) {
+                        String expectedPackages = candidates.stream()
+                                .map(JavaClass::getPackageName)
+                                .collect(Collectors.joining("] or ["));
+                        String message = String.format(
+                                "%s should be in package [%s] but was found in [%s] %s",
+                                testClass.getSimpleName(),
+                                expectedPackages,
+                                testClass.getPackageName(),
+                                testClass.getSourceCodeLocation()
+                        );
+                        events.add(SimpleConditionEvent.violated(testClass, message));
+                    }
+                }
+            })
+            .because("""
+                    a consistent structure makes code easier to work with.
+                    
+                    Context:
+                    Test classes are generally created in the same package as what they're testing. \
+                    However, subsequent refactorings may cause them to drift, as it's easy to forget to move the tests \
+                    when moving the production class. This causes the project structure to become messy, making \
+                    tests harder to find than they should be.
+                    
+                    Positive consequences:
+                    - Test classes will be easier to find without the help of the IDE.
+                    """);
+
+    static {
+        JavaClasses productionClasses = new ClassFileImporter()
+                .withImportOption(new ImportOption.DoNotIncludeTests())
+                .importPackagesOf(BackityApplication.class);
+
+        Map<String, List<JavaClass>> index = new HashMap<>();
+        for (JavaClass clazz : productionClasses) {
+            if (clazz.getEnclosingClass().isPresent()) continue;
+            index.computeIfAbsent(clazz.getSimpleName(), k -> new ArrayList<>()).add(clazz);
+        }
+        PRODUCTION_CLASSES_BY_SIMPLE_NAME = Collections.unmodifiableMap(index);
+    }
+
     private static ArchCondition<JavaMethod> followShouldGivenConvention() {
         return new ArchCondition<>("follow 'should...(given)' naming convention") {
 
@@ -102,6 +244,26 @@ public class TestRules {
                 }
             }
         };
+    }
+
+    private static Optional<String> resolveTestDisplayName(JavaMethod method) {
+        if (method.isAnnotatedWith(DisplayName.class)) {
+            return Optional.of(method.getAnnotationOfType(DisplayName.class).value());
+        }
+        if (method.isAnnotatedWith(ParameterizedTest.class)) {
+            String name = method.getAnnotationOfType(ParameterizedTest.class).name();
+            if (!name.equals("{default_display_name}") && !name.isBlank()) {
+                return Optional.of(name);
+            }
+        }
+        if (method.isAnnotatedWith(RepeatedTest.class)) {
+            String name = method.getAnnotationOfType(RepeatedTest.class).name();
+            if (!name.equals(RepeatedTest.SHORT_DISPLAY_NAME) &&
+                    !name.equals(RepeatedTest.DISPLAY_NAME_PLACEHOLDER)) {
+                return Optional.of(name);
+            }
+        }
+        return Optional.empty();
     }
 
     private static ArchCondition<JavaMethod> notContainWhenOrIf() {
@@ -158,82 +320,6 @@ public class TestRules {
                 }
             }
         };
-    }
-
-    private static Optional<String> resolveTestDisplayName(JavaMethod method) {
-        if (method.isAnnotatedWith(DisplayName.class)) {
-            return Optional.of(method.getAnnotationOfType(DisplayName.class).value());
-        }
-        if (method.isAnnotatedWith(ParameterizedTest.class)) {
-            String name = method.getAnnotationOfType(ParameterizedTest.class).name();
-            if (!name.equals("{default_display_name}") && !name.isBlank()) {
-                return Optional.of(name);
-            }
-        }
-        if (method.isAnnotatedWith(RepeatedTest.class)) {
-            String name = method.getAnnotationOfType(RepeatedTest.class).name();
-            if (!name.equals(RepeatedTest.SHORT_DISPLAY_NAME) &&
-                    !name.equals(RepeatedTest.DISPLAY_NAME_PLACEHOLDER)) {
-                return Optional.of(name);
-            }
-        }
-        return Optional.empty();
-    }
-
-    /// Ensures that all test classes with the same name as the class they're testing reside in the same package as that
-    /// class. E.g., SomeClassTest should reside in the same package as SomeClass.
-    @ArchTest
-    static void testClassesShouldResideInCorrectPackage(JavaClasses testClasses) {
-        JavaClasses productionClasses = new ClassFileImporter()
-                .withImportOption(new ImportOption.DoNotIncludeTests())
-                .importPackagesOf(BackityApplication.class);
-
-        Map<String, List<JavaClass>> productionClassesBySimpleName = new HashMap<>();
-        for (JavaClass clazz : productionClasses) {
-            if (clazz.getEnclosingClass().isPresent()) {
-                continue; // Skip nested, inner, local, and anonymous classes
-            }
-            productionClassesBySimpleName
-                    .computeIfAbsent(clazz.getSimpleName(), k -> new ArrayList<>())
-                    .add(clazz);
-        }
-
-        List<String> errors = new ArrayList<>();
-        for (JavaClass testClass : testClasses) {
-            if (testClass.getEnclosingClass().isPresent()) {
-                continue; // Skip nested, inner, local, and anonymous classes
-            }
-
-            String testedSimpleName = stripTestSuffix(testClass.getSimpleName());
-            if (testedSimpleName.equals(testClass.getSimpleName())) {
-                continue; // Not a test class (no recognized suffix was stripped)
-            }
-
-            List<JavaClass> candidates = productionClassesBySimpleName.get(testedSimpleName);
-            if (candidates == null) {
-                continue;
-            }
-
-            boolean packageMatches = candidates.stream()
-                    .anyMatch(pc -> pc.getPackageName().equals(testClass.getPackageName()));
-
-            if (!packageMatches) {
-                String expectedPackages = candidates.stream()
-                        .map(JavaClass::getPackageName)
-                        .collect(Collectors.joining("] or ["));
-                errors.add(String.format(
-                        "%s should be in package [%s] but was found in [%s] %s",
-                        testClass.getSimpleName(),
-                        expectedPackages,
-                        testClass.getPackageName(),
-                        testClass.getSourceCodeLocation()
-                ));
-            }
-        }
-
-        if (!errors.isEmpty()) {
-            fail(String.join("\n", errors));
-        }
     }
 
     private static String stripTestSuffix(String simpleName) {

--- a/backend/src/test/java/dev/codesoapbox/backity/core/backup/application/FileBackupServiceTest.java
+++ b/backend/src/test/java/dev/codesoapbox/backity/core/backup/application/FileBackupServiceTest.java
@@ -168,9 +168,7 @@ class FileBackupServiceTest {
                 gameProviderIsConnectedFor(fileBackupContext.sourceFile());
                 PersistedChangesToFileCopy persistedChangesToFileCopy = trackPersistedChangesToFileCopy();
                 aUniqueFilePathIsResolvedFor(fileBackupContext);
-                doThrow(new FileWriteWasCanceledException(aFilePath, storageSolution))
-                        .when(fileCopyReplicator).replicate(storageSolution, fileBackupContext.sourceFile(),
-                                fileBackupContext.fileCopy());
+                backupIsCanceledDuringReplication(aFilePath, storageSolution, fileBackupContext);
 
                 fileBackupService.backUpFile(fileBackupContext);
 
@@ -186,13 +184,17 @@ class FileBackupServiceTest {
                 FilePath filePath = aUniqueFilePathIsResolvedFor(fileBackupContext);
                 storageSolution.createFile(filePath);
                 gameProviderIsConnectedFor(fileBackupContext.sourceFile());
-                doThrow(new FileWriteWasCanceledException(filePath, storageSolution))
-                        .when(fileCopyReplicator).replicate(storageSolution, fileBackupContext.sourceFile(),
-                                fileBackupContext.fileCopy());
+                backupIsCanceledDuringReplication(filePath, storageSolution, fileBackupContext);
 
                 fileBackupService.backUpFile(fileBackupContext);
 
                 assertThat(storageSolution.fileExists(filePath)).isFalse();
+            }
+
+            private void backupIsCanceledDuringReplication(FilePath filePath, FakeUnixStorageSolution storageSolution, FileBackupContext fileBackupContext) {
+                doThrow(new FileWriteWasCanceledException(filePath, storageSolution))
+                        .when(fileCopyReplicator).replicate(storageSolution, fileBackupContext.sourceFile(),
+                                fileBackupContext.fileCopy());
             }
 
             @Test
@@ -203,9 +205,7 @@ class FileBackupServiceTest {
                         .build();
                 FilePath filePath = aUniqueFilePathIsResolvedFor(fileBackupContext);
                 gameProviderIsConnectedFor(fileBackupContext.sourceFile());
-                doThrow(new FileWriteWasCanceledException(filePath, storageSolution))
-                        .when(fileCopyReplicator).replicate(storageSolution, fileBackupContext.sourceFile(),
-                                fileBackupContext.fileCopy());
+                backupIsCanceledDuringReplication(filePath, storageSolution, fileBackupContext);
 
                 fileBackupService.backUpFile(fileBackupContext);
 

--- a/backend/src/test/java/dev/codesoapbox/backity/core/backup/application/FileCopyReplicatorTest.java
+++ b/backend/src/test/java/dev/codesoapbox/backity/core/backup/application/FileCopyReplicatorTest.java
@@ -106,7 +106,7 @@ class FileCopyReplicatorTest {
         void shouldReturnTrueGivenConnected() {
             SourceFile sourceFile = TestSourceFile.gog();
             gameProviderExistsFor(sourceFile);
-            mockGameProviderIsConnected();
+            gameProviderIsConnected();
             var fileCopyReplicator = new FileCopyReplicator(
                     List.of(gameProviderFileBackupService), outputStreamProgressTrackerFactory, storageSolutionWriteService);
 
@@ -115,7 +115,7 @@ class FileCopyReplicatorTest {
             assertThat(result).isTrue();
         }
 
-        private void mockGameProviderIsConnected() {
+        private void gameProviderIsConnected() {
             when(gameProviderFileBackupService.isConnected())
                     .thenReturn(true);
         }

--- a/backend/src/test/java/dev/codesoapbox/backity/core/backup/application/usecases/RecoverInterruptedFileBackupUseCaseTest.java
+++ b/backend/src/test/java/dev/codesoapbox/backity/core/backup/application/usecases/RecoverInterruptedFileBackupUseCaseTest.java
@@ -49,10 +49,12 @@ class RecoverInterruptedFileBackupUseCaseTest {
 
     @Test
     void shouldRecoverInterruptedFileBackup() {
-        FileCopy fileCopy = mockInProgressFileCopyExists();
-        FakeUnixStorageSolution storageSolution = mockStorageSolutionExists();
+        FileCopy fileCopy = TestFileCopy.inProgress();
+        FakeUnixStorageSolution storageSolution = aStorageSolution();
         storageSolution.createFile(fileCopy.getFilePath());
-        mockBackupTargetExists(fileCopy, storageSolution);
+        existsInProgress(fileCopy);
+        exists(storageSolution);
+        aBackupTargetExists(fileCopy, storageSolution);
         FilePath filePathToDelete = fileCopy.getFilePath();
 
         useCase.execute();
@@ -66,14 +68,12 @@ class RecoverInterruptedFileBackupUseCaseTest {
         assertThat(savedFileCopy.getFilePath()).isNull();
     }
 
-    private FileCopy mockInProgressFileCopyExists() {
-        FileCopy fileCopy = TestFileCopy.inProgress();
+    private void existsInProgress(FileCopy fileCopy) {
         when(fileCopyRepository.findAllInProgress())
                 .thenReturn(List.of(fileCopy));
-        return fileCopy;
     }
 
-    private void mockBackupTargetExists(FileCopy fileCopy, StorageSolution storageSolution) {
+    private void aBackupTargetExists(FileCopy fileCopy, StorageSolution storageSolution) {
         BackupTarget backupTarget = TestBackupTarget.localFolderBuilder()
                 .withId(fileCopy.getNaturalId().backupTargetId())
                 .withStorageSolutionId(storageSolution.getId())
@@ -82,12 +82,13 @@ class RecoverInterruptedFileBackupUseCaseTest {
                 .thenReturn(List.of(backupTarget));
     }
 
-    private FakeUnixStorageSolution mockStorageSolutionExists() {
-        var storageSolution = new FakeUnixStorageSolution();
+    private FakeUnixStorageSolution aStorageSolution() {
+        return new FakeUnixStorageSolution();
+    }
+
+    private void exists(FakeUnixStorageSolution storageSolution) {
         when(storageSolutionRepository.findAll())
                 .thenReturn(List.of(storageSolution));
-
-        return storageSolution;
     }
 
     private FileCopy getSavedFileCopy() {
@@ -98,9 +99,11 @@ class RecoverInterruptedFileBackupUseCaseTest {
 
     @Test
     void shouldPublishEventOnCompletion() {
-        FileCopy fileCopy = mockInProgressFileCopyExists();
-        FakeUnixStorageSolution storageSolution = mockStorageSolutionExists();
-        mockBackupTargetExists(fileCopy, storageSolution);
+        FileCopy fileCopy = TestFileCopy.inProgress();
+        existsInProgress(fileCopy);
+        FakeUnixStorageSolution storageSolution = aStorageSolution();
+        exists(storageSolution);
+        aBackupTargetExists(fileCopy, storageSolution);
 
         useCase.execute();
 

--- a/backend/src/test/java/dev/codesoapbox/backity/core/backuptarget/application/GetBackupTargetsUseCaseTest.java
+++ b/backend/src/test/java/dev/codesoapbox/backity/core/backuptarget/application/GetBackupTargetsUseCaseTest.java
@@ -29,17 +29,18 @@ class GetBackupTargetsUseCaseTest {
 
     @Test
     void shouldGetBackupTargets() {
-        List<BackupTarget> backupTargets = mockBackupTargetsExist();
+        List<BackupTarget> backupTargets = backupTargetsExist();
 
         List<BackupTarget> result = useCase.execute();
 
         assertThat(result).isEqualTo(backupTargets);
     }
 
-    private List<BackupTarget> mockBackupTargetsExist() {
+    private List<BackupTarget> backupTargetsExist() {
         List<BackupTarget> backupTargets = List.of(TestBackupTarget.localFolder());
         when(backupTargetRepository.findAll())
                 .thenReturn(backupTargets);
+
         return backupTargets;
     }
 }

--- a/backend/src/test/java/dev/codesoapbox/backity/core/backuptarget/infrastructure/adapters/driving/api/http/controllers/AddBackupTargetControllerIT.java
+++ b/backend/src/test/java/dev/codesoapbox/backity/core/backuptarget/infrastructure/adapters/driving/api/http/controllers/AddBackupTargetControllerIT.java
@@ -74,8 +74,7 @@ class AddBackupTargetControllerIT {
                 .withPathTemplate(new PathTemplate("games/{GAME_PROVIDER_ID}/{GAME_TITLE}/{FILENAME}"))
                 .build();
         AddBackupTargetCommand command = toAddBackupTargetCommand(expectedBackupTarget);
-        when(useCase.execute(command))
-                .thenReturn(expectedBackupTarget);
+        backupTargetIsAdded(command, expectedBackupTarget);
 
         mockMvc.perform(post("/api/" + BackupTargetsRestResource.RESOURCE_URL)
                         .contentType(MediaType.APPLICATION_JSON)
@@ -98,6 +97,11 @@ class AddBackupTargetControllerIT {
                             }
                         }
                         """));
+    }
+
+    private void backupTargetIsAdded(AddBackupTargetCommand command, BackupTarget expectedBackupTarget) {
+        when(useCase.execute(command))
+                .thenReturn(expectedBackupTarget);
     }
 
     private AddBackupTargetCommand toAddBackupTargetCommand(BackupTarget expectedBackupTarget) {

--- a/backend/src/test/java/dev/codesoapbox/backity/core/backuptarget/infrastructure/adapters/driving/api/http/controllers/GetBackupTargetsControllerIT.java
+++ b/backend/src/test/java/dev/codesoapbox/backity/core/backuptarget/infrastructure/adapters/driving/api/http/controllers/GetBackupTargetsControllerIT.java
@@ -28,8 +28,7 @@ class GetBackupTargetsControllerIT {
     @Test
     void shouldGetBackupTargets() throws Exception {
         BackupTarget backupTarget = TestBackupTarget.localFolder();
-        when(useCase.execute())
-                .thenReturn(List.of(backupTarget));
+        useCaseReturns(backupTarget);
 
         var expectedJson = """
                 [
@@ -45,5 +44,10 @@ class GetBackupTargetsControllerIT {
                 .andDo(print())
                 .andExpect(status().isOk())
                 .andExpect(content().json(expectedJson));
+    }
+
+    private void useCaseReturns(BackupTarget backupTarget) {
+        when(useCase.execute())
+                .thenReturn(List.of(backupTarget));
     }
 }

--- a/backend/src/test/java/dev/codesoapbox/backity/core/backuptarget/infrastructure/adapters/driving/api/http/controllers/GetLockedBackupTargetIdsControllerIT.java
+++ b/backend/src/test/java/dev/codesoapbox/backity/core/backuptarget/infrastructure/adapters/driving/api/http/controllers/GetLockedBackupTargetIdsControllerIT.java
@@ -2,6 +2,7 @@ package dev.codesoapbox.backity.core.backuptarget.infrastructure.adapters.drivin
 
 import dev.codesoapbox.backity.core.backuptarget.application.GetLockedBackupTargetIdsUseCase;
 import dev.codesoapbox.backity.core.backuptarget.domain.BackupTarget;
+import dev.codesoapbox.backity.core.backuptarget.domain.BackupTargetId;
 import dev.codesoapbox.backity.core.backuptarget.domain.TestBackupTarget;
 import dev.codesoapbox.backity.testing.http.annotations.ControllerTest;
 import org.junit.jupiter.api.Test;
@@ -28,8 +29,7 @@ class GetLockedBackupTargetIdsControllerIT {
     @Test
     void shouldGetLockedBackupTargetIds() throws Exception {
         BackupTarget backupTarget = TestBackupTarget.localFolder();
-        when(useCase.execute())
-                .thenReturn(List.of(backupTarget.getId()));
+        useCaseReturns(List.of(backupTarget.getId()));
 
         var expectedJson = """
                 [
@@ -40,5 +40,10 @@ class GetLockedBackupTargetIdsControllerIT {
                 .andDo(print())
                 .andExpect(status().isOk())
                 .andExpect(content().json(expectedJson));
+    }
+
+    private void useCaseReturns(List<BackupTargetId> backupTargetIds) {
+        when(useCase.execute())
+                .thenReturn(backupTargetIds);
     }
 }

--- a/backend/src/test/java/dev/codesoapbox/backity/core/discovery/application/GameContentDiscoveryProgressTrackerTest.java
+++ b/backend/src/test/java/dev/codesoapbox/backity/core/discovery/application/GameContentDiscoveryProgressTrackerTest.java
@@ -51,12 +51,16 @@ class GameContentDiscoveryProgressTrackerTest {
     void setUp() {
         clock = FakeClock.atEpochUtc();
         gameProviderFileDiscoveryService = new FakeGameProviderFileDiscoveryService();
-        when(anotherGameProviderFileDiscoveryService.getGameProviderId())
-                .thenReturn(new GameProviderId("anotherGameProviderId"));
+        anotherGameProviderFileDiscoveryServiceWorks();
         tracker = new GameContentDiscoveryProgressTracker(
                 clock, domainEventPublisher, discoveryResultRepository,
                 List.of(gameProviderFileDiscoveryService, anotherGameProviderFileDiscoveryService),
                 resetProviderTrackerWhenNewRequested());
+    }
+
+    private void anotherGameProviderFileDiscoveryServiceWorks() {
+        when(anotherGameProviderFileDiscoveryService.getGameProviderId())
+                .thenReturn(new GameProviderId("anotherGameProviderId"));
     }
 
     private Function<GameProviderId, GameProviderContentDiscoveryTracker> resetProviderTrackerWhenNewRequested() {
@@ -76,18 +80,26 @@ class GameContentDiscoveryProgressTrackerTest {
 
         @Test
         void shouldReturnFalseGivenNotInProgress() {
-            when(providerTracker.isInProgress())
-                    .thenReturn(false);
+            isNotInProgress();
 
             assertThat(tracker.isInProgress(gameProviderFileDiscoveryService)).isFalse();
         }
 
+        private void isNotInProgress() {
+            when(providerTracker.isInProgress())
+                    .thenReturn(false);
+        }
+
         @Test
         void ShouldReturnTrueGivenInProgress() {
-            when(providerTracker.isInProgress())
-                    .thenReturn(true);
+            isInProgress();
 
             assertThat(tracker.isInProgress(gameProviderFileDiscoveryService)).isTrue();
+        }
+
+        private void isInProgress() {
+            when(providerTracker.isInProgress())
+                    .thenReturn(true);
         }
     }
 
@@ -155,14 +167,14 @@ class GameContentDiscoveryProgressTrackerTest {
             tracker.initializeTracking(
                     gameProviderFileDiscoveryService.getGameProviderId()); // To set in progressTracker to true
             reset(providerTracker); // To make sure any assertions on behavior don't include setup behavior
-            mockProviderTrackerReturnsDiscoveryResult();
+            providerTrackerReturnsDiscoveryResult();
 
             tracker.finalizeTracking(gameProviderFileDiscoveryService.getGameProviderId());
 
             verify(providerTracker).setInProgress(false);
         }
 
-        private GameContentDiscoveryResult mockProviderTrackerReturnsDiscoveryResult() {
+        private GameContentDiscoveryResult providerTrackerReturnsDiscoveryResult() {
             GameContentDiscoveryResult result = mock(GameContentDiscoveryResult.class);
             lenient().when(providerTracker.getResult())
                     .thenReturn(result);
@@ -171,7 +183,7 @@ class GameContentDiscoveryProgressTrackerTest {
 
         @Test
         void shouldSetStoppedAt() {
-            mockProviderTrackerReturnsDiscoveryResult();
+            providerTrackerReturnsDiscoveryResult();
 
             tracker.finalizeTracking(gameProviderFileDiscoveryService.getGameProviderId());
 
@@ -180,7 +192,7 @@ class GameContentDiscoveryProgressTrackerTest {
 
         @Test
         void shouldSaveDiscoveryResult() {
-            GameContentDiscoveryResult discoveryResult = mockProviderTrackerReturnsDiscoveryResult();
+            GameContentDiscoveryResult discoveryResult = providerTrackerReturnsDiscoveryResult();
 
             tracker.finalizeTracking(gameProviderFileDiscoveryService.getGameProviderId());
 
@@ -189,7 +201,7 @@ class GameContentDiscoveryProgressTrackerTest {
 
         @Test
         void shouldSendDiscoveryStoppedEvent() {
-            GameContentDiscoveryResult discoveryResult = mockProviderTrackerReturnsDiscoveryResult();
+            GameContentDiscoveryResult discoveryResult = providerTrackerReturnsDiscoveryResult();
 
             tracker.finalizeTracking(gameProviderFileDiscoveryService.getGameProviderId());
 
@@ -230,9 +242,9 @@ class GameContentDiscoveryProgressTrackerTest {
         @Test
         void shouldGetDiscoveryOverviews() {
             GameProviderId gameProviderId = gameProviderFileDiscoveryService.getGameProviderId();
-            mockProviderTrackerIsInProgress();
-            GameContentDiscoveryProgress discoveryProgress = mockProviderTrackerReturnsProgress();
-            GameContentDiscoveryResult contentDiscoveryResult = mockDiscoveryResultExistsInRepository(gameProviderId);
+            providerTrackerIsInProgress();
+            GameContentDiscoveryProgress discoveryProgress = providerTrackerReturnsProgress();
+            GameContentDiscoveryResult contentDiscoveryResult = discoveryResultExistsInRepository(gameProviderId);
 
             List<GameContentDiscoveryOverview> result = tracker.getDiscoveryOverviews();
 
@@ -241,7 +253,7 @@ class GameContentDiscoveryProgressTrackerTest {
             assertThat(result).contains(expectedResult);
         }
 
-        private GameContentDiscoveryResult mockDiscoveryResultExistsInRepository(GameProviderId gameProviderId) {
+        private GameContentDiscoveryResult discoveryResultExistsInRepository(GameProviderId gameProviderId) {
             GameContentDiscoveryResult contentDiscoveryResult = mock(GameContentDiscoveryResult.class);
             lenient().when(contentDiscoveryResult.getGameProviderId())
                     .thenReturn(gameProviderId);
@@ -251,12 +263,12 @@ class GameContentDiscoveryProgressTrackerTest {
             return contentDiscoveryResult;
         }
 
-        private void mockProviderTrackerIsInProgress() {
+        private void providerTrackerIsInProgress() {
             when(providerTracker.isInProgress())
                     .thenReturn(true);
         }
 
-        private GameContentDiscoveryProgress mockProviderTrackerReturnsProgress() {
+        private GameContentDiscoveryProgress providerTrackerReturnsProgress() {
             GameContentDiscoveryProgress discoveryProgress = mock(GameContentDiscoveryProgress.class);
             when(providerTracker.getProgress())
                     .thenReturn(discoveryProgress);

--- a/backend/src/test/java/dev/codesoapbox/backity/core/discovery/application/GameContentDiscoveryServiceTest.java
+++ b/backend/src/test/java/dev/codesoapbox/backity/core/discovery/application/GameContentDiscoveryServiceTest.java
@@ -52,22 +52,22 @@ class GameContentDiscoveryServiceTest {
         gameContentDiscoveryService = new GameContentDiscoveryService(singletonList(gameProviderFileDiscoveryService),
                 gameRepository, fileRepository, discoveryProgressTracker, Executors.newVirtualThreadPerTaskExecutor());
 
-        mockDiscoveryTrackerTracksInProgressStatus();
+        discoveryTrackerTracksInProgressStatus();
     }
 
-    private void mockDiscoveryTrackerTracksInProgressStatus() {
-        lenient().doAnswer(inv -> {
+    private void discoveryTrackerTracksInProgressStatus() {
+        lenient().doAnswer(_ -> {
                     discoveryIsInProgress = true;
                     return null;
                 }).when(discoveryProgressTracker)
                 .initializeTracking(gameProviderFileDiscoveryService.getGameProviderId());
-        lenient().doAnswer(inv -> {
+        lenient().doAnswer(_ -> {
                     discoveryIsInProgress = false;
                     return null;
                 }).when(discoveryProgressTracker)
                 .finalizeTracking(gameProviderFileDiscoveryService.getGameProviderId());
         lenient().when(discoveryProgressTracker.isInProgress(eq(gameProviderFileDiscoveryService)))
-                .thenAnswer(inv -> discoveryIsInProgress);
+                .thenAnswer(_ -> discoveryIsInProgress);
     }
 
     @AfterEach
@@ -173,7 +173,7 @@ class GameContentDiscoveryServiceTest {
         @Test
         void shouldNotSaveGameInformationGivenGameAlreadyExists() {
             DiscoveredFile discoveredFile = TestDiscoveredFile.minimalGog();
-            mockGameExists(discoveredFile.originalGameTitle());
+            gameExists(discoveredFile.originalGameTitle());
 
             gameContentDiscoveryService =
                     new GameContentDiscoveryService(singletonList(gameProviderFileDiscoveryService),
@@ -187,7 +187,7 @@ class GameContentDiscoveryServiceTest {
             verify(gameRepository, never()).save(any());
         }
 
-        private Game mockGameExists(GameTitle title) {
+        private Game gameExists(GameTitle title) {
             Game game = TestGame.anyBuilder()
                     .withTitle(title)
                     .build();
@@ -200,7 +200,7 @@ class GameContentDiscoveryServiceTest {
         @Test
         void shouldSaveGameInformationGivenItDoesNotYetExist() {
             DiscoveredFile discoveredFile = TestDiscoveredFile.minimalGog();
-            mockGameDoesNotExist(discoveredFile.originalGameTitle());
+            noGamesExist();
 
             gameContentDiscoveryService.startContentDiscovery();
             waitForGameProviderFileDiscoveryToBeTriggered();
@@ -210,8 +210,8 @@ class GameContentDiscoveryServiceTest {
             assertThat(savedGame.getTitle()).isEqualTo(discoveredFile.originalGameTitle());
         }
 
-        private void mockGameDoesNotExist(GameTitle gameTitle) {
-            when(gameRepository.findByTitle(gameTitle))
+        private void noGamesExist() {
+            when(gameRepository.findByTitle(any()))
                     .thenReturn(Optional.empty());
         }
 
@@ -224,8 +224,8 @@ class GameContentDiscoveryServiceTest {
         @Test
         void shouldSaveSourceFiles() {
             DiscoveredFile discoveredFile = TestDiscoveredFile.minimalGog();
-            Game game = mockGameExists(discoveredFile.originalGameTitle());
-            mockSourceFileDoesNotExist(discoveredFile);
+            Game game = gameExists(discoveredFile.originalGameTitle());
+            noSourceFileExists();
 
             gameContentDiscoveryService.startContentDiscovery();
             waitForGameProviderFileDiscoveryToBeTriggered();
@@ -249,16 +249,16 @@ class GameContentDiscoveryServiceTest {
             return sourceFileArgumentCaptor.getValue();
         }
 
-        private void mockSourceFileDoesNotExist(DiscoveredFile discoveredFile) {
-            when(fileRepository.existsByUrlAndVersion(discoveredFile.url(), discoveredFile.version()))
+        private void noSourceFileExists() {
+            when(fileRepository.existsByUrlAndVersion(any(), any()))
                     .thenReturn(false);
         }
 
         @Test
         void shouldIncrementSourceFilesDiscovered() {
             DiscoveredFile discoveredFile = TestDiscoveredFile.minimalGog();
-            mockGameExists(discoveredFile.originalGameTitle());
-            mockSourceFileDoesNotExist(discoveredFile);
+            gameExists(discoveredFile.originalGameTitle());
+            noSourceFileExists();
 
             gameContentDiscoveryService.startContentDiscovery();
             waitForGameProviderFileDiscoveryToBeTriggered();
@@ -271,7 +271,7 @@ class GameContentDiscoveryServiceTest {
         @Test
         void shouldIncrementGamesDiscovered() {
             DiscoveredFile discoveredFile = TestDiscoveredFile.minimalGog();
-            mockGameDoesNotExist(discoveredFile.originalGameTitle());
+            noGamesExist();
 
             gameContentDiscoveryService.startContentDiscovery();
             waitForGameProviderFileDiscoveryToBeTriggered();
@@ -284,7 +284,7 @@ class GameContentDiscoveryServiceTest {
         @Test
         void shouldNotSaveSourceFileGivenAlreadyExists() {
             DiscoveredFile discoveredFile = TestDiscoveredFile.minimalGog();
-            mockSourceFileExistsLocally(discoveredFile);
+            sourceFileExistsLocally(discoveredFile);
 
             gameContentDiscoveryService.startContentDiscovery();
 
@@ -295,7 +295,7 @@ class GameContentDiscoveryServiceTest {
             verify(discoveryProgressTracker, never()).incrementSourceFilesDiscovered(any(), anyInt());
         }
 
-        private void mockSourceFileExistsLocally(DiscoveredFile discoveredFile) {
+        private void sourceFileExistsLocally(DiscoveredFile discoveredFile) {
             when(fileRepository.existsByUrlAndVersion(discoveredFile.url(), discoveredFile.version()))
                     .thenReturn(true);
         }

--- a/backend/src/test/java/dev/codesoapbox/backity/core/discovery/application/usecases/GetGameContentDiscoveryOverviewsUseCaseTest.java
+++ b/backend/src/test/java/dev/codesoapbox/backity/core/discovery/application/usecases/GetGameContentDiscoveryOverviewsUseCaseTest.java
@@ -29,7 +29,7 @@ class GetGameContentDiscoveryOverviewsUseCaseTest {
 
     @Test
     void shouldGetDiscoveryOverviews() {
-        List<GameContentDiscoveryOverview> overviews = mockGameContentDiscoveryOverviews();
+        List<GameContentDiscoveryOverview> overviews = trackerHasSomeDiscoveryOverviews();
 
         List<GameContentDiscoveryOverview> result = useCase.execute();
 
@@ -37,7 +37,7 @@ class GetGameContentDiscoveryOverviewsUseCaseTest {
                 .isEqualTo(overviews);
     }
 
-    private List<GameContentDiscoveryOverview> mockGameContentDiscoveryOverviews() {
+    private List<GameContentDiscoveryOverview> trackerHasSomeDiscoveryOverviews() {
         var gameProviderId = new GameProviderId("TestGameProviderId");
         List<GameContentDiscoveryOverview> overviews =
                 List.of(new GameContentDiscoveryOverview(

--- a/backend/src/test/java/dev/codesoapbox/backity/core/discovery/infrastructure/adapters/driving/api/http/controllers/GetGameContentDiscoveryOverviewsControllerIT.java
+++ b/backend/src/test/java/dev/codesoapbox/backity/core/discovery/infrastructure/adapters/driving/api/http/controllers/GetGameContentDiscoveryOverviewsControllerIT.java
@@ -35,8 +35,7 @@ class GetGameContentDiscoveryOverviewsControllerIT {
                 TestGameContentDiscoveryProgress.twentyFivePercentGog(),
                 TestGameContentDiscoveryResult.gog()
         );
-        when(useCase.execute())
-                .thenReturn(List.of(overview));
+        exists(overview);
         var expectedJson = """
                 [{
                   "gameProviderId": "TestGameProviderId",
@@ -59,5 +58,10 @@ class GetGameContentDiscoveryOverviewsControllerIT {
                 .andDo(print())
                 .andExpect(status().isOk())
                 .andExpect(content().json(expectedJson));
+    }
+
+    private void exists(GameContentDiscoveryOverview overview) {
+        when(useCase.execute())
+                .thenReturn(List.of(overview));
     }
 }

--- a/backend/src/test/java/dev/codesoapbox/backity/core/filecopy/application/FileCopyWithContextFactoryTest.java
+++ b/backend/src/test/java/dev/codesoapbox/backity/core/filecopy/application/FileCopyWithContextFactoryTest.java
@@ -58,10 +58,10 @@ class FileCopyWithContextFactoryTest {
         var pagination = new Pagination(0, 1);
         FileCopy fileCopy = TestFileCopy.enqueued();
         Page<FileCopy> fileCopyPage = TestPage.of(List.of(fileCopy), pagination);
-        SourceFile sourceFile = mockSourceFileExists(fileCopy);
-        Game game = mockGameExists(sourceFile);
-        BackupTarget backupTarget = mockBackupTargetExists(fileCopy);
-        FileCopyReplicationProgress replicationProgress = mockReplicationProgressExists(fileCopy);
+        SourceFile sourceFile = sourceFileExists(fileCopy);
+        Game game = gameExists(sourceFile);
+        BackupTarget backupTarget = backupTargetExists(fileCopy);
+        FileCopyReplicationProgress replicationProgress = replicationProgressExists(fileCopy);
 
         Page<FileCopyWithContext> result = fileCopyWithContextFactory.createPageFrom(fileCopyPage);
 
@@ -72,7 +72,7 @@ class FileCopyWithContextFactoryTest {
                 .isEqualTo(expectedResult);
     }
 
-    private SourceFile mockSourceFileExists(FileCopy fileCopy) {
+    private SourceFile sourceFileExists(FileCopy fileCopy) {
         SourceFile sourceFile = TestSourceFile.gogBuilder()
                 .id(fileCopy.getNaturalId().sourceFileId())
                 .build();
@@ -82,7 +82,7 @@ class FileCopyWithContextFactoryTest {
         return sourceFile;
     }
 
-    private Game mockGameExists(SourceFile sourceFile) {
+    private Game gameExists(SourceFile sourceFile) {
         Game game = TestGame.anyBuilder()
                 .withId(sourceFile.getGameId())
                 .build();
@@ -92,7 +92,7 @@ class FileCopyWithContextFactoryTest {
         return game;
     }
 
-    private BackupTarget mockBackupTargetExists(FileCopy fileCopy) {
+    private BackupTarget backupTargetExists(FileCopy fileCopy) {
         BackupTarget backupTarget = TestBackupTarget.localFolderBuilder()
                 .withId(fileCopy.getNaturalId().backupTargetId())
                 .build();
@@ -102,7 +102,7 @@ class FileCopyWithContextFactoryTest {
         return backupTarget;
     }
 
-    private FileCopyReplicationProgress mockReplicationProgressExists(FileCopy fileCopy) {
+    private FileCopyReplicationProgress replicationProgressExists(FileCopy fileCopy) {
         FileCopyReplicationProgress replicationProgress = TestFileCopyReplicationProgress.twentyFivePercent();
         when(replicationProgressRepository.findAllByFileCopyIdIn(Set.of(fileCopy.getId())))
                 .thenReturn(List.of(replicationProgress));

--- a/backend/src/test/java/dev/codesoapbox/backity/core/filecopy/application/usecases/CancelFileCopyUseCaseTest.java
+++ b/backend/src/test/java/dev/codesoapbox/backity/core/filecopy/application/usecases/CancelFileCopyUseCaseTest.java
@@ -41,20 +41,20 @@ class CancelFileCopyUseCaseTest {
 
     @Test
     void shouldDoNothingGivenFileCopyNotEnqueuedAndNotInProgress() {
-        FileCopy fileCopy = mockTrackedFileCopyExists();
+        FileCopy fileCopy = trackedFileCopyExists();
 
         useCase.execute(fileCopy.getId());
         verifyNoMoreInteractions(fileCopyRepository, storageSolutionWriteService);
     }
 
-    private FileCopy mockTrackedFileCopyExists() {
+    private FileCopy trackedFileCopyExists() {
         FileCopy fileCopy = TestFileCopy.tracked();
-        return mockFileCopyExists(fileCopy);
+        return fileCopyExists(fileCopy);
     }
 
     @Test
     void shouldCancelEnqueuedFileCopy() {
-        FileCopy fileCopy = mockEnqueuedFileCopyExists();
+        FileCopy fileCopy = enqueuedFileCopyExists();
 
         useCase.execute(fileCopy.getId());
 
@@ -63,12 +63,12 @@ class CancelFileCopyUseCaseTest {
         verifyNoInteractions(storageSolutionWriteService);
     }
 
-    private FileCopy mockEnqueuedFileCopyExists() {
+    private FileCopy enqueuedFileCopyExists() {
         FileCopy fileCopy = TestFileCopy.enqueued();
-        return mockFileCopyExists(fileCopy);
+        return fileCopyExists(fileCopy);
     }
 
-    private FileCopy mockFileCopyExists(FileCopy fileCopy) {
+    private FileCopy fileCopyExists(FileCopy fileCopy) {
         when(fileCopyRepository.getById(fileCopy.getId()))
                 .thenReturn(fileCopy);
         return fileCopy;
@@ -82,8 +82,8 @@ class CancelFileCopyUseCaseTest {
 
     @Test
     void shouldCancelInProgressFileCopy() {
-        FileCopy fileCopy = mockInProgressFileCopyExists();
-        BackupTarget backupTarget = mockBackupTargetExistsFor(fileCopy);
+        FileCopy fileCopy = inProgressFileCopyExists();
+        BackupTarget backupTarget = backupTargetExistsFor(fileCopy);
         FilePath filePath = fileCopy.getFilePath();
 
         useCase.execute(fileCopy.getId());
@@ -93,15 +93,15 @@ class CancelFileCopyUseCaseTest {
         verifyNoMoreInteractions(fileCopyRepository);
     }
 
-    private BackupTarget mockBackupTargetExistsFor(FileCopy fileCopy) {
+    private BackupTarget backupTargetExistsFor(FileCopy fileCopy) {
         BackupTarget backupTarget = TestBackupTarget.localFolder();
         when(backupTargetRepository.getById(fileCopy.getNaturalId().backupTargetId()))
                 .thenReturn(backupTarget);
         return backupTarget;
     }
 
-    private FileCopy mockInProgressFileCopyExists() {
+    private FileCopy inProgressFileCopyExists() {
         FileCopy fileCopy = TestFileCopy.inProgress();
-        return mockFileCopyExists(fileCopy);
+        return fileCopyExists(fileCopy);
     }
 }

--- a/backend/src/test/java/dev/codesoapbox/backity/core/filecopy/application/usecases/DeleteFileCopyUseCaseTest.java
+++ b/backend/src/test/java/dev/codesoapbox/backity/core/filecopy/application/usecases/DeleteFileCopyUseCaseTest.java
@@ -39,9 +39,9 @@ class DeleteFileCopyUseCaseTest {
 
     @Test
     void shouldDeleteFileCopyGivenSourceFileStatusIsStoredIntegrityUnknown() {
-        FileCopy fileCopy = mockStoredUnverifiedFileCopyExists();
+        FileCopy fileCopy = storedUnverifiedFileCopyExists();
         FilePath filePath = fileCopy.getFilePath();
-        FakeUnixStorageSolution storageSolution = mockStorageSolutionExists(fileCopy);
+        FakeUnixStorageSolution storageSolution = storageSolutionExists(fileCopy);
         storageSolution.createFile(filePath);
 
         useCase.execute(fileCopy.getId());
@@ -49,26 +49,26 @@ class DeleteFileCopyUseCaseTest {
         assertThat(storageSolution.fileExists(filePath)).isFalse();
     }
 
-    private FileCopy mockStoredUnverifiedFileCopyExists() {
+    private FileCopy storedUnverifiedFileCopyExists() {
         FileCopy fileCopy = TestFileCopy.storedIntegrityUnknown();
         when(fileCopyRepository.getById(fileCopy.getId()))
                 .thenReturn(fileCopy);
         return fileCopy;
     }
 
-    private FakeUnixStorageSolution mockStorageSolutionExists(FileCopy fileCopy) {
-        BackupTarget backupTarget = mockBackupTargetExists(fileCopy);
-        return mockStorageSolutionExists(backupTarget);
+    private FakeUnixStorageSolution storageSolutionExists(FileCopy fileCopy) {
+        BackupTarget backupTarget = backupTargetExists(fileCopy);
+        return storageSolutionExists(backupTarget);
     }
 
-    private FakeUnixStorageSolution mockStorageSolutionExists(BackupTarget backupTarget) {
+    private FakeUnixStorageSolution storageSolutionExists(BackupTarget backupTarget) {
         var storageSolution = new FakeUnixStorageSolution();
         lenient().when(storageSolutionRepository.getById(backupTarget.getStorageSolutionId()))
                 .thenReturn(storageSolution);
         return storageSolution;
     }
 
-    private BackupTarget mockBackupTargetExists(FileCopy fileCopy) {
+    private BackupTarget backupTargetExists(FileCopy fileCopy) {
         BackupTarget backupTarget = TestBackupTarget.localFolder();
         lenient().when(backupTargetRepository.getById(fileCopy.getNaturalId().backupTargetId()))
                 .thenReturn(backupTarget);
@@ -77,8 +77,8 @@ class DeleteFileCopyUseCaseTest {
 
     @Test
     void shouldChangeStatusOfFileCopyGivenDeletingFile() {
-        FileCopy fileCopy = mockStoredUnverifiedFileCopyExists();
-        mockStorageSolutionExists(fileCopy);
+        FileCopy fileCopy = storedUnverifiedFileCopyExists();
+        storageSolutionExists(fileCopy);
 
         useCase.execute(fileCopy.getId());
 
@@ -88,8 +88,8 @@ class DeleteFileCopyUseCaseTest {
 
     @Test
     void shouldNotChangeStatusOfSourceFileGivenFileDeletionFailed() {
-        FileCopy fileCopy = mockStoredUnverifiedFileCopyExists();
-        FakeUnixStorageSolution storageSolution = mockStorageSolutionExists(fileCopy);
+        FileCopy fileCopy = storedUnverifiedFileCopyExists();
+        FakeUnixStorageSolution storageSolution = storageSolutionExists(fileCopy);
         var exception = new RuntimeException("test");
         storageSolution.setShouldThrowOnFileDeletion(exception);
 
@@ -101,8 +101,8 @@ class DeleteFileCopyUseCaseTest {
     }
 
     @Test
-    void shouldThrowGivenSourceFilestatusIsNotStored() {
-        FileCopy fileCopy = mockEnqueuedFileCopyExists();
+    void shouldThrowGivenSourceFileStatusIsNotStored() {
+        FileCopy fileCopy = enqueuedFileCopyExists();
         FileCopyId fileCopyId = fileCopy.getId();
 
         assertThatThrownBy(() -> useCase.execute(fileCopyId))
@@ -110,7 +110,7 @@ class DeleteFileCopyUseCaseTest {
                 .hasMessageContaining(fileCopyId.toString());
     }
 
-    private FileCopy mockEnqueuedFileCopyExists() {
+    private FileCopy enqueuedFileCopyExists() {
         FileCopy fileCopy = TestFileCopy.enqueued();
         when(fileCopyRepository.getById(fileCopy.getId()))
                 .thenReturn(fileCopy);

--- a/backend/src/test/java/dev/codesoapbox/backity/core/filecopy/application/usecases/DownloadFileCopyUseCaseTest.java
+++ b/backend/src/test/java/dev/codesoapbox/backity/core/filecopy/application/usecases/DownloadFileCopyUseCaseTest.java
@@ -1,11 +1,14 @@
 package dev.codesoapbox.backity.core.filecopy.application.usecases;
 
 import dev.codesoapbox.backity.core.backuptarget.domain.BackupTarget;
+import dev.codesoapbox.backity.core.backuptarget.domain.BackupTargetId;
 import dev.codesoapbox.backity.core.backuptarget.domain.BackupTargetRepository;
 import dev.codesoapbox.backity.core.backuptarget.domain.TestBackupTarget;
 import dev.codesoapbox.backity.core.filecopy.domain.FileCopy;
+import dev.codesoapbox.backity.core.filecopy.domain.FileCopyNaturalId;
 import dev.codesoapbox.backity.core.filecopy.domain.FileCopyRepository;
 import dev.codesoapbox.backity.core.filecopy.domain.TestFileCopy;
+import dev.codesoapbox.backity.core.sourcefile.domain.SourceFileId;
 import dev.codesoapbox.backity.core.storagesolution.domain.FileResource;
 import dev.codesoapbox.backity.core.storagesolution.domain.StorageSolution;
 import dev.codesoapbox.backity.core.storagesolution.domain.StorageSolutionRepository;
@@ -44,48 +47,55 @@ class DownloadFileCopyUseCaseTest {
 
     @Test
     void shouldDownloadFileGivenFileCopyExistsAndFileCopyResourceExists() throws FileNotFoundException {
-        FileCopy fileCopy = mockStoredUnverifiedFileCopyExists();
-        StorageSolution storageSolution = mockStorageSolutionExists(fileCopy);
-        FileResource fileResource = mockFileResourceExists(fileCopy, storageSolution);
+        BackupTarget backupTarget = TestBackupTarget.localFolder();
+        FileCopy fileCopy = TestFileCopy.storedIntegrityUnknownBuilder()
+                .naturalId(aFileCopyNaturalId(backupTarget.getId()))
+                .build();
+        FileResource fileResource = aFileResource();
+        StorageSolution storageSolution = aStorageSolution(backupTarget, fileCopy, fileResource);
+        exists(fileCopy);
+        exists(backupTarget);
+        exists(storageSolution);
 
         FileResource result = downloadFileCopyUseCase.execute(fileCopy.getId());
 
         assertThat(result).isEqualTo(fileResource);
     }
 
-    private FileCopy mockStoredUnverifiedFileCopyExists() {
-        FileCopy fileCopy = TestFileCopy.storedIntegrityUnknown();
-        when(fileCopyRepository.getById(fileCopy.getId()))
-                .thenReturn(fileCopy);
-
-        return fileCopy;
+    private FileCopyNaturalId aFileCopyNaturalId(BackupTargetId backupTargetId) {
+        return new FileCopyNaturalId(
+                new SourceFileId("c7384581-b74e-4df4-b6e9-04046c9afca6"),
+                backupTargetId
+        );
     }
 
-    private StorageSolution mockStorageSolutionExists(FileCopy fileCopy) {
-        BackupTarget backupTarget = mockBackupTargetExists(fileCopy);
-        return mockStorageSolutionExists(backupTarget);
+    private FileResource aFileResource() {
+        return new FileResource(mock(InputStream.class), 5120L, "test_file.exe");
     }
 
-    private StorageSolution mockStorageSolutionExists(BackupTarget backupTarget) {
+    private StorageSolution aStorageSolution(BackupTarget backupTarget, FileCopy fileCopy, FileResource fileResource)
+            throws FileNotFoundException {
         StorageSolution storageSolution = mock(StorageSolution.class);
-        when(storageSolutionRepository.getById(backupTarget.getStorageSolutionId()))
-                .thenReturn(storageSolution);
+        when(storageSolution.getFileResource(fileCopy.getFilePath()))
+                .thenReturn(fileResource);
+        when(storageSolution.getId())
+                .thenReturn(backupTarget.getStorageSolutionId());
+
         return storageSolution;
     }
 
-    private BackupTarget mockBackupTargetExists(FileCopy fileCopy) {
-        BackupTarget backupTarget = TestBackupTarget.localFolder();
-        when(backupTargetRepository.getById(fileCopy.getNaturalId().backupTargetId()))
-                .thenReturn(backupTarget);
-        return backupTarget;
+    private void exists(FileCopy fileCopy) {
+        when(fileCopyRepository.getById(fileCopy.getId()))
+                .thenReturn(fileCopy);
     }
 
-    private FileResource mockFileResourceExists(FileCopy fileCopy, StorageSolution storageSolution)
-            throws FileNotFoundException {
-        FileResource fileResource = new FileResource(mock(InputStream.class), 5120L, "test_file.exe");
-        when(storageSolution.getFileResource(fileCopy.getFilePath()))
-                .thenReturn(fileResource);
+    private void exists(StorageSolution storageSolution) {
+        when(storageSolutionRepository.getById(storageSolution.getId()))
+                .thenReturn(storageSolution);
+    }
 
-        return fileResource;
+    private void exists(BackupTarget backupTarget) {
+        when(backupTargetRepository.getById(backupTarget.getId()))
+                .thenReturn(backupTarget);
     }
 }

--- a/backend/src/test/java/dev/codesoapbox/backity/core/filecopy/application/usecases/EnqueueFileCopyUseCaseTest.java
+++ b/backend/src/test/java/dev/codesoapbox/backity/core/filecopy/application/usecases/EnqueueFileCopyUseCaseTest.java
@@ -37,7 +37,8 @@ class EnqueueFileCopyUseCaseTest {
 
     @Test
     void shouldSetFileCopyStatusToEnqueuedAndPersistIt() {
-        FileCopy fileCopy = mockTrackedFileCopyExists();
+        FileCopy fileCopy = TestFileCopy.tracked();
+        exists(fileCopy);
 
         useCase.execute(fileCopy.getNaturalId());
 
@@ -45,15 +46,12 @@ class EnqueueFileCopyUseCaseTest {
         verify(fileCopyRepository).save(fileCopy);
     }
 
-    private FileCopy mockTrackedFileCopyExists() {
-        FileCopy fileCopy = TestFileCopy.tracked();
+    private void exists(FileCopy fileCopy) {
         when(fileCopyRepository.getByNaturalIdOrCreate(eq(fileCopy.getNaturalId()), any()))
                 .thenAnswer(inv -> {
                     checkFactoryWasPassed(inv);
                     return fileCopy;
                 });
-
-        return fileCopy;
     }
 
     private void checkFactoryWasPassed(InvocationOnMock inv) {
@@ -62,7 +60,8 @@ class EnqueueFileCopyUseCaseTest {
 
     @Test
     void shouldPassFileCopySupplierToRepository() {
-        FileCopy fileCopy = mockTrackedFileCopyExists();
+        FileCopy fileCopy = TestFileCopy.tracked();
+        exists(fileCopy);
         AtomicBoolean factoryWasPassed = trackFactoryWasPassed(fileCopy);
 
         useCase.execute(fileCopy.getNaturalId());
@@ -79,6 +78,7 @@ class EnqueueFileCopyUseCaseTest {
                     }
                     return null;
                 });
+        
         return factoryWasPassed;
     }
 }

--- a/backend/src/test/java/dev/codesoapbox/backity/core/filecopy/application/usecases/GetFileCopyQueueUseCaseTest.java
+++ b/backend/src/test/java/dev/codesoapbox/backity/core/filecopy/application/usecases/GetFileCopyQueueUseCaseTest.java
@@ -20,6 +20,7 @@ import java.util.List;
 
 import static java.util.Collections.emptyList;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
@@ -42,14 +43,14 @@ class GetFileCopyQueueUseCaseTest {
     @Test
     void shouldGetFileCopyQueue() {
         var pagination = new Pagination(0, 10);
-        Page<FileCopyWithContext> fileCopyWithContextPage = mockFileCopyPageExists(pagination);
+        Page<FileCopyWithContext> fileCopyWithContextPage = fileCopyPageExists(pagination);
 
         Page<FileCopyWithContext> result = useCase.execute(pagination);
 
         assertThat(result).isEqualTo(fileCopyWithContextPage);
     }
 
-    private Page<FileCopyWithContext> mockFileCopyPageExists(Pagination pagination) {
+    private Page<FileCopyWithContext> fileCopyPageExists(Pagination pagination) {
         Page<FileCopy> fileCopyPage = TestPage.of(List.of(TestFileCopy.enqueued()), pagination);
         when(fileCopyRepository.findAllInProgressOrEnqueued(pagination))
                 .thenReturn(fileCopyPage);
@@ -77,12 +78,17 @@ class GetFileCopyQueueUseCaseTest {
     @Test
     void shouldNotUseFileCopyWithContextFactoryGivenNoFileCopiesInQueue() {
         var pagination = new Pagination(0, 10);
-        when(fileCopyRepository.findAllInProgressOrEnqueued(pagination))
-                .thenReturn(TestPage.of(emptyList(), pagination));
+        noFileCopiesExist();
 
         Page<FileCopyWithContext> result = useCase.execute(pagination);
 
         assertThat(result).isNotNull();
         verifyNoInteractions(fileCopyWithContextFactory);
+    }
+
+    private void noFileCopiesExist() {
+        when(fileCopyRepository.findAllInProgressOrEnqueued(any()))
+                .thenAnswer(inv ->
+                        TestPage.of(emptyList(), inv.getArgument(0, Pagination.class)));
     }
 }

--- a/backend/src/test/java/dev/codesoapbox/backity/core/filecopy/infrastructure/adapters/driven/persistence/jpa/FileCopyJpaRepositoryIT.java
+++ b/backend/src/test/java/dev/codesoapbox/backity/core/filecopy/infrastructure/adapters/driven/persistence/jpa/FileCopyJpaRepositoryIT.java
@@ -292,6 +292,16 @@ abstract class FileCopyJpaRepositoryIT {
         FileCopy newFileCopy = TestFileCopy.trackedBuilder()
                 .naturalId(naturalId)
                 .build();
+        aggregateIsCreatedConcurrently(mockSpringRepository, naturalId, expectedExisting);
+
+        FileCopy result = repository.getByNaturalIdOrCreate(naturalId, () -> newFileCopy);
+
+        assertThat(result)
+                .usingRecursiveComparison()
+                .isEqualTo(expectedExisting);
+    }
+
+    private void aggregateIsCreatedConcurrently(FileCopySpringRepository mockSpringRepository, FileCopyNaturalId naturalId, FileCopy expectedExisting) {
         when(mockSpringRepository.findByNaturalIdSourceFileIdAndNaturalIdBackupTargetId(
                 naturalId.sourceFileId().value(), naturalId.backupTargetId().value()))
                 // Nothing in DB during initial lookup:
@@ -303,12 +313,6 @@ abstract class FileCopyJpaRepositoryIT {
                 naturalId.sourceFileId().value(), naturalId.backupTargetId().value()))
                 // Someone saved before second lookup:
                 .thenReturn(entityMapper.toEntity(expectedExisting));
-
-        FileCopy result = repository.getByNaturalIdOrCreate(naturalId, () -> newFileCopy);
-
-        assertThat(result)
-                .usingRecursiveComparison()
-                .isEqualTo(expectedExisting);
     }
 
     @Test

--- a/backend/src/test/java/dev/codesoapbox/backity/core/filecopy/infrastructure/adapters/driving/api/http/controllers/CancelFileCopyControllerIT.java
+++ b/backend/src/test/java/dev/codesoapbox/backity/core/filecopy/infrastructure/adapters/driving/api/http/controllers/CancelFileCopyControllerIT.java
@@ -8,7 +8,8 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.web.servlet.MockMvc;
 
-import static org.mockito.Mockito.doThrow;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.verify;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
@@ -35,14 +36,17 @@ class CancelFileCopyControllerIT {
     }
 
     @Test
-    void shouldReturnNotFoundForNonExistentFile() throws Exception {
+    void shouldReturnNotFoundForNonExistentFileCopy() throws Exception {
         var stringUuid = "6df888e8-90b9-4df5-a237-0cba422c0310";
-        var fileCopyId = new FileCopyId(stringUuid);
-
-        doThrow(new FileCopyNotFoundException(fileCopyId))
-                .when(useCase).execute(fileCopyId);
+        noFileCopiesExist();
 
         mockMvc.perform(delete("/api/" + FileCopyQueueRestResource.RESOURCE_URL + "/" + stringUuid))
                 .andExpect(status().isNotFound());
+    }
+
+    private void noFileCopiesExist() {
+        doAnswer(inv -> {
+            throw new FileCopyNotFoundException(inv.getArgument(0));
+        }).when(useCase).execute(any());
     }
 }

--- a/backend/src/test/java/dev/codesoapbox/backity/core/filecopy/infrastructure/adapters/driving/api/http/controllers/DownloadFileCopyControllerIT.java
+++ b/backend/src/test/java/dev/codesoapbox/backity/core/filecopy/infrastructure/adapters/driving/api/http/controllers/DownloadFileCopyControllerIT.java
@@ -33,7 +33,7 @@ class DownloadFileCopyControllerIT {
         var fileCopyId = new FileCopyId(stringUuid);
         byte[] fileContent = "Test file content".getBytes();
         @SuppressWarnings("resource")
-        FileResource fileResource = mockFileResourceExists(fileContent, fileCopyId);
+        FileResource fileResource = fileResourceExists(fileContent, fileCopyId);
 
         mockMvc.perform(get("/api/" + FileCopiesRestResource.RESOURCE_URL + "/" + stringUuid)
                         .accept(MediaType.APPLICATION_OCTET_STREAM))
@@ -47,7 +47,7 @@ class DownloadFileCopyControllerIT {
                         "attachment; filename=\"" + fileResource.fileName() + "\""));
     }
 
-    private FileResource mockFileResourceExists(byte[] fileContent, FileCopyId fileCopyId)
+    private FileResource fileResourceExists(byte[] fileContent, FileCopyId fileCopyId)
             throws FileNotFoundException {
         InputStream inputStream = new ByteArrayInputStream(fileContent);
         FileResource fileResource = new FileResource(inputStream, fileContent.length, "test_file.exe");
@@ -59,24 +59,23 @@ class DownloadFileCopyControllerIT {
     }
 
     @Test
-    void shouldReturnNotFoundForNonExistentFile() throws Exception {
+    void shouldReturnNotFoundForNonExistentFileCopy() throws Exception {
         var stringUuid = "6df888e8-90b9-4df5-a237-0cba422c0310";
-        var fileCopyId = new FileCopyId(stringUuid);
-
-        when(useCase.execute(fileCopyId))
-                .thenThrow(new FileNotFoundException("File not found"));
+        noFileCopiesExist();
 
         mockMvc.perform(get("/api/" + FileCopiesRestResource.RESOURCE_URL + "/" + stringUuid))
                 .andExpect(status().isNotFound());
     }
 
+    private void noFileCopiesExist() throws FileNotFoundException {
+        when(useCase.execute(any()))
+                .thenThrow(new FileNotFoundException("File not found"));
+    }
+
     @Test
     void shouldReturnInternalServerErrorOnUseCaseException() throws Exception {
         var stringUuid = "6df888e8-90b9-4df5-a237-0cba422c0310";
-        var fileCopyId = new FileCopyId(stringUuid);
-
-        when(useCase.execute(fileCopyId))
-                .thenThrow(new RuntimeException("Something went wrong"));
+        useCaseThrows();
 
         mockMvc.perform(get("/api/" + FileCopiesRestResource.RESOURCE_URL + "/" + stringUuid))
                 .andExpect(status().isInternalServerError());
@@ -86,14 +85,14 @@ class DownloadFileCopyControllerIT {
     void shouldCloseResourceAndRethrowGivenRuntimeExceptionAfterAcquiringResource() throws Exception {
         var stringUuid = "6df888e8-90b9-4df5-a237-0cba422c0310";
         var fileCopyId = new FileCopyId(stringUuid);
-        FileResource fileResource = mockThrowingFileResourceExists(fileCopyId);
+        FileResource fileResource = throwingFileResourceExists(fileCopyId);
 
         mockMvc.perform(get("/api/" + FileCopiesRestResource.RESOURCE_URL + "/" + stringUuid))
                 .andExpect(status().isInternalServerError());
         verify(fileResource).close();
     }
 
-    private FileResource mockThrowingFileResourceExists(FileCopyId fileCopyId) throws FileNotFoundException {
+    private FileResource throwingFileResourceExists(FileCopyId fileCopyId) throws FileNotFoundException {
         FileResource fileResource = mock(FileResource.class);
         when(useCase.execute(fileCopyId))
                 .thenReturn(fileResource);
@@ -103,14 +102,8 @@ class DownloadFileCopyControllerIT {
         return fileResource;
     }
 
-    @Test
-    void shouldRethrowGivenRuntimeExceptionDuringAcquiringResource() throws Exception {
-        var stringUuid = "6df888e8-90b9-4df5-a237-0cba422c0310";
-        var fileCopyId = new FileCopyId(stringUuid);
-        when(useCase.execute(fileCopyId))
+    private void useCaseThrows() throws FileNotFoundException {
+        when(useCase.execute(any()))
                 .thenThrow(new RuntimeException("Test exception"));
-
-        mockMvc.perform(get("/api/" + FileCopiesRestResource.RESOURCE_URL + "/" + stringUuid))
-                .andExpect(status().isInternalServerError());
     }
 }

--- a/backend/src/test/java/dev/codesoapbox/backity/core/filecopy/infrastructure/adapters/driving/api/http/controllers/EnqueueFileCopyControllerIT.java
+++ b/backend/src/test/java/dev/codesoapbox/backity/core/filecopy/infrastructure/adapters/driving/api/http/controllers/EnqueueFileCopyControllerIT.java
@@ -15,6 +15,7 @@ import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -59,9 +60,7 @@ class EnqueueFileCopyControllerIT {
         var backupTargetUuid = "224440e2-6e5c-4f24-94ac-3222587652f7";
         var sourceFileId = new SourceFileId(sourceFileUuid);
         var backupTargetId = new BackupTargetId(backupTargetUuid);
-        var fileCopyNaturalId = new FileCopyNaturalId(sourceFileId, backupTargetId);
-        doThrow(new FileCopyNotFoundException(sourceFileId, backupTargetId))
-                .when(useCase).execute(fileCopyNaturalId);
+        noFileCopiesExist(sourceFileId, backupTargetId);
 
         mockMvc.perform(post("/api/" + FileCopyQueueRestResource.RESOURCE_URL)
                         .contentType(MediaType.APPLICATION_JSON)
@@ -80,5 +79,10 @@ class EnqueueFileCopyControllerIT {
                 .contains("Could not enqueue file copy.")
                 .contains(sourceFileUuid)
                 .contains(backupTargetUuid);
+    }
+
+    private void noFileCopiesExist(SourceFileId sourceFileId, BackupTargetId backupTargetId) {
+        doThrow(new FileCopyNotFoundException(sourceFileId, backupTargetId))
+                .when(useCase).execute(any());
     }
 }

--- a/backend/src/test/java/dev/codesoapbox/backity/core/filecopy/infrastructure/adapters/driving/api/http/controllers/GetFileCopyQueueControllerIT.java
+++ b/backend/src/test/java/dev/codesoapbox/backity/core/filecopy/infrastructure/adapters/driving/api/http/controllers/GetFileCopyQueueControllerIT.java
@@ -36,7 +36,7 @@ class GetFileCopyQueueControllerIT {
     @Test
     void shouldGetQueue() throws Exception {
         var expectedPagination = new Pagination(0, 1);
-        mockEnqueuedFileExists(expectedPagination);
+        anEnqueuedFileExists(expectedPagination);
         var expectedJson = """
                 {
                   "content": [
@@ -88,7 +88,7 @@ class GetFileCopyQueueControllerIT {
                 .andExpect(content().json(expectedJson));
     }
 
-    private void mockEnqueuedFileExists(Pagination expectedPagination) {
+    private void anEnqueuedFileExists(Pagination expectedPagination) {
         var fileCopyWithContext = new FileCopyWithContext(
                 TestFileCopy.enqueued(),
                 TestSourceFile.gog(),

--- a/backend/src/test/java/dev/codesoapbox/backity/core/game/application/usecases/GetGamesWithFilesUseCaseTest.java
+++ b/backend/src/test/java/dev/codesoapbox/backity/core/game/application/usecases/GetGamesWithFilesUseCaseTest.java
@@ -49,8 +49,9 @@ class GetGamesWithFilesUseCaseTest {
         var searchQuery = "someSearchQuery";
         GameWithFileCopiesSearchFilter filter = TestGameWithFileCopiesSearchFilter.onlySearchQuery(searchQuery);
         FileCopy localCopy = TestFileCopy.storedIntegrityUnknown();
-        GameWithFileCopiesReadModel game = mockGameIsFound(localCopy, pagination, filter);
-        FileCopyReplicationProgress replicationProgress = mockReplicationProgressExists(localCopy);
+        GameWithFileCopiesReadModel game = gameWithFileCopiesExists(localCopy, pagination, filter);
+        FileCopyReplicationProgress replicationProgress = TestFileCopyReplicationProgress.twentyFivePercent();
+        replicationProgressExistsForFileCopy(replicationProgress, localCopy);
 
         Page<GameWithFileCopiesAndReplicationProgresses> result = useCase.execute(pagination, filter);
 
@@ -61,8 +62,8 @@ class GetGamesWithFilesUseCaseTest {
                 .usingRecursiveComparison().isEqualTo(expectedResult);
     }
 
-    private GameWithFileCopiesReadModel mockGameIsFound(FileCopy localCopy, Pagination pagination,
-                                                        GameWithFileCopiesSearchFilter filter) {
+    private GameWithFileCopiesReadModel gameWithFileCopiesExists(FileCopy localCopy, Pagination pagination,
+                                                                 GameWithFileCopiesSearchFilter filter) {
         GameWithFileCopiesReadModel game = TestGameWithFileCopiesReadModel.withNoSourceFilesBuilder()
                 .withSourceFilesWithCopies(List.of(
                         new SourceFileWithCopiesReadModel(
@@ -77,11 +78,10 @@ class GetGamesWithFilesUseCaseTest {
         return game;
     }
 
-    private FileCopyReplicationProgress mockReplicationProgressExists(FileCopy localCopy) {
-        FileCopyReplicationProgress replicationProgress = TestFileCopyReplicationProgress.twentyFivePercent();
+    private void replicationProgressExistsForFileCopy(
+            FileCopyReplicationProgress replicationProgress, FileCopy localCopy) {
         when(replicationProgressRepository.findAllByFileCopyIdIn(Set.of(localCopy.getId())))
                 .thenReturn(List.of(replicationProgress));
-        return replicationProgress;
     }
 
     @Test
@@ -90,7 +90,7 @@ class GetGamesWithFilesUseCaseTest {
         var searchQuery = "someSearchQuery";
         GameWithFileCopiesSearchFilter filter = TestGameWithFileCopiesSearchFilter.onlySearchQuery(searchQuery);
         FileCopy localCopy = TestFileCopy.storedIntegrityUnknown();
-        GameWithFileCopiesReadModel game = mockGameIsFound(localCopy, pagination, filter);
+        GameWithFileCopiesReadModel game = gameWithFileCopiesExists(localCopy, pagination, filter);
 
         Page<GameWithFileCopiesAndReplicationProgresses> result = useCase.execute(pagination, filter);
 

--- a/backend/src/test/java/dev/codesoapbox/backity/core/game/infrastructure/adapters/driving/api/http/controllers/GetGamesControllerIT.java
+++ b/backend/src/test/java/dev/codesoapbox/backity/core/game/infrastructure/adapters/driving/api/http/controllers/GetGamesControllerIT.java
@@ -69,8 +69,7 @@ class GetGamesControllerIT {
                                 .build())
                 )
         ), pagination);
-        when(getGamesWithFilesUseCase.execute(pagination, expectedFilter))
-                .thenReturn(gameWithFileCopiesPage);
+        gamesWithFileCopiesExist(pagination, expectedFilter, gameWithFileCopiesPage);
 
         mockMvc.perform(get("/api/games?page=0&size=2"))
                 .andExpect(status().isOk())
@@ -186,11 +185,16 @@ class GetGamesControllerIT {
                                 .build())
                 )
         ), pagination);
-        when(getGamesWithFilesUseCase.execute(pagination, expectedFilter))
-                .thenReturn(gameWithFileCopiesPage);
+        gamesWithFileCopiesExist(pagination, expectedFilter, gameWithFileCopiesPage);
 
         mockMvc.perform(get("/api/games?page=0&size=2&query=someSearchQuery&file-copy-status=ENQUEUED"))
                 .andExpect(status().isOk())
                 .andExpect(content().json(expectedJsonResponse()));
+    }
+
+    private void gamesWithFileCopiesExist(Pagination pagination, GameWithFileCopiesSearchFilter expectedFilter,
+                                          Page<GameWithFileCopiesAndReplicationProgresses> gameWithFileCopiesPage) {
+        when(getGamesWithFilesUseCase.execute(pagination, expectedFilter))
+                .thenReturn(gameWithFileCopiesPage);
     }
 }

--- a/backend/src/test/java/dev/codesoapbox/backity/core/storagesolution/application/GetStorageSolutionStatusesUseCaseTest.java
+++ b/backend/src/test/java/dev/codesoapbox/backity/core/storagesolution/application/GetStorageSolutionStatusesUseCaseTest.java
@@ -31,8 +31,7 @@ class GetStorageSolutionStatusesUseCaseTest {
 
     @Test
     void shouldGetStorageSolutionStatuses() {
-        when(storageSolutionRepository.findAll())
-                .thenReturn(List.of(new FakeUnixStorageSolution()));
+        storageSolutionRepositoryContainsFakeUnixSolution();
 
         Map<StorageSolutionId, StorageSolutionStatus> result = useCase.execute();
 
@@ -40,5 +39,10 @@ class GetStorageSolutionStatusesUseCaseTest {
                 FakeUnixStorageSolution.DEFAULT_ID, StorageSolutionStatus.CONNECTED
         );
         assertThat(result).isEqualTo(expectedResult);
+    }
+
+    private void storageSolutionRepositoryContainsFakeUnixSolution() {
+        when(storageSolutionRepository.findAll())
+                .thenReturn(List.of(new FakeUnixStorageSolution()));
     }
 }

--- a/backend/src/test/java/dev/codesoapbox/backity/core/storagesolution/infrastructure/adapters/driven/filesystem/S3StorageSolutionIT.java
+++ b/backend/src/test/java/dev/codesoapbox/backity/core/storagesolution/infrastructure/adapters/driven/filesystem/S3StorageSolutionIT.java
@@ -143,13 +143,10 @@ class S3StorageSolutionIT {
                     .isInstanceOf(FileNotFoundException.class);
         }
 
-        @SuppressWarnings("unchecked")
         @Test
         void shouldThrowGivenException() {
-            S3Client s3Client = mock(S3Client.class);
             var expectedCause = new RuntimeException("Test exception");
-            when(s3Client.deleteObject(any(Consumer.class)))
-                    .thenThrow(expectedCause);
+            S3Client s3Client = s3ClientThrowingOnDeletion(expectedCause);
             s3StorageSolution = new S3StorageSolution(s3Client, BUCKET_NAME, BUFFER_SIZE_IN_BYTES);
             var filePath = new FilePath(S3_FILE_1_KEY);
 
@@ -157,6 +154,14 @@ class S3StorageSolutionIT {
                     .isInstanceOf(FileCouldNotBeDeletedException.class)
                     .hasMessageContaining(S3_FILE_1_KEY)
                     .hasCause(expectedCause);
+        }
+
+        @SuppressWarnings("unchecked")
+        private S3Client s3ClientThrowingOnDeletion(RuntimeException expectedCause) {
+            S3Client s3Client = mock(S3Client.class);
+            when(s3Client.deleteObject(any(Consumer.class)))
+                    .thenThrow(expectedCause);
+            return s3Client;
         }
 
         @Test

--- a/backend/src/test/java/dev/codesoapbox/backity/core/storagesolution/infrastructure/adapters/driving/api/http/controllers/GetStorageSolutionStatusesControllerIT.java
+++ b/backend/src/test/java/dev/codesoapbox/backity/core/storagesolution/infrastructure/adapters/driving/api/http/controllers/GetStorageSolutionStatusesControllerIT.java
@@ -27,11 +27,11 @@ class GetStorageSolutionStatusesControllerIT {
 
     @Test
     void shouldGetStorageSolutionStatuses() throws Exception {
-        when(useCase.execute())
-                .thenReturn(Map.of(
-                        new StorageSolutionId("LOCAL_FILE_SYSTEM"), StorageSolutionStatus.CONNECTED,
-                        new StorageSolutionId("S3"), StorageSolutionStatus.NOT_CONNECTED
-                ));
+        Map<StorageSolutionId, StorageSolutionStatus> statuses = Map.of(
+                new StorageSolutionId("LOCAL_FILE_SYSTEM"), StorageSolutionStatus.CONNECTED,
+                new StorageSolutionId("S3"), StorageSolutionStatus.NOT_CONNECTED
+        );
+        statusesExist(statuses);
         var expectedJson = """
                 {
                   "statuses": {
@@ -45,5 +45,10 @@ class GetStorageSolutionStatusesControllerIT {
                 .andDo(print())
                 .andExpect(status().isOk())
                 .andExpect(content().json(expectedJson));
+    }
+
+    private void statusesExist(Map<StorageSolutionId, StorageSolutionStatus> statuses) {
+        when(useCase.execute())
+                .thenReturn(statuses);
     }
 }

--- a/backend/src/test/java/dev/codesoapbox/backity/gameproviders/gog/infrastructure/adapters/driven/api/spring/auth/GogAuthSpringServiceTest.java
+++ b/backend/src/test/java/dev/codesoapbox/backity/gameproviders/gog/infrastructure/adapters/driven/api/spring/auth/GogAuthSpringServiceTest.java
@@ -2,12 +2,16 @@ package dev.codesoapbox.backity.gameproviders.gog.infrastructure.adapters.driven
 
 import dev.codesoapbox.backity.gameproviders.gog.infrastructure.adapters.driven.api.spring.auth.exceptions.GogAuthException;
 import dev.codesoapbox.backity.gameproviders.gog.infrastructure.adapters.driven.api.spring.auth.model.remote.GogAuthenticationResponse;
+import dev.codesoapbox.backity.gameproviders.gog.infrastructure.adapters.driven.api.spring.auth.model.remote.TestGogAuthenticationResponse;
+import dev.codesoapbox.backity.testing.time.FakeClock;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Duration;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -16,17 +20,21 @@ import static org.mockito.Mockito.*;
 @ExtendWith(MockitoExtension.class)
 class GogAuthSpringServiceTest {
 
-    @InjectMocks
     private GogAuthSpringService gogAuthService;
 
     @Mock
     private GogAuthClient gogAuthClient;
 
-    private void authenticateCorrectly(int expiresInSeconds) {
+    private FakeClock clock;
+
+    @BeforeEach
+    void setUp() {
+        clock = FakeClock.atEpochUtc();
+        gogAuthService = new GogAuthSpringService(clock, gogAuthClient);
+    }
+
+    private void authenticateCorrectly(GogAuthenticationResponse gogAuthResponse) {
         var code = "someCode";
-        var gogAuthResponse = new GogAuthenticationResponse(
-                "someAccessToken", "someRefreshToken", expiresInSeconds,
-                "someSessionId", "someUserId");
 
         when(gogAuthClient.getInitialToken(code))
                 .thenReturn(gogAuthResponse);
@@ -34,12 +42,17 @@ class GogAuthSpringServiceTest {
         gogAuthService.authenticate(code);
     }
 
+    private void tokenCanBeRefreshed(String oldRefreshToken, GogAuthenticationResponse gogAuthResponseRefreshed) {
+        when(gogAuthClient.refreshToken(oldRefreshToken))
+                .thenReturn(gogAuthResponseRefreshed);
+    }
+
     @Nested
     class Authentication {
 
         @Test
         void shouldAuthenticate() {
-            authenticateCorrectly(3600);
+            authenticateCorrectly(TestGogAuthenticationResponse.valid());
 
             assertThat(gogAuthService.isAuthenticated()).isTrue();
         }
@@ -51,7 +64,9 @@ class GogAuthSpringServiceTest {
 
         @Test
         void shouldReturnFalseGivenAuthenticationExpired() {
-            authenticateCorrectly(-1);
+            GogAuthenticationResponse gogAuthResponse = TestGogAuthenticationResponse.valid();
+            authenticateCorrectly(gogAuthResponse);
+            clock.moveForward(Duration.ofSeconds(gogAuthResponse.getExpiresIn()));
 
             assertThat(gogAuthService.isAuthenticated()).isFalse();
         }
@@ -61,31 +76,13 @@ class GogAuthSpringServiceTest {
     class Refresh {
 
         @Test
-        void shouldRefresh() {
-            var gogAuthResponseRefreshed = new GogAuthenticationResponse("someAccessToken",
-                    "someRefreshToken", 3600, "someSessionId", "someUserId");
-
-            when(gogAuthClient.refreshToken("someRefreshToken"))
-                    .thenReturn(gogAuthResponseRefreshed);
-
-            authenticateCorrectly(-1);
+        void shouldRefreshAuthentication() {
+            GogAuthenticationResponse gogAuthResponse = TestGogAuthenticationResponse.valid();
+            authenticateCorrectly(gogAuthResponse);
+            clock.moveForward(Duration.ofSeconds(gogAuthResponse.getExpiresIn()));
+            tokenCanBeRefreshed(gogAuthResponse.getRefreshToken(), gogAuthResponse);
 
             gogAuthService.refresh();
-
-            assertThat(gogAuthService.isAuthenticated()).isTrue();
-        }
-
-        @Test
-        void shouldRefreshWithNewRefreshToken() {
-            var gogAuthResponseRefreshed = new GogAuthenticationResponse("someAccessToken",
-                    "someRefreshToken", 3600, "someSessionId", "someUserId");
-
-            when(gogAuthClient.refreshToken("someCustomRefreshToken"))
-                    .thenReturn(gogAuthResponseRefreshed);
-
-            authenticateCorrectly(-1);
-
-            gogAuthService.refresh("someCustomRefreshToken");
 
             assertThat(gogAuthService.isAuthenticated()).isTrue();
         }
@@ -95,22 +92,37 @@ class GogAuthSpringServiceTest {
     class GetAccessToken {
 
         @Test
-        void shouldGetAccessToken() {
-            authenticateCorrectly(3600);
+        void shouldReturnAccessTokenGivenAuthenticatedAndNotExpired() {
+            GogAuthenticationResponse gogAuthResponse = TestGogAuthenticationResponse.valid();
+            authenticateCorrectly(gogAuthResponse);
 
-            assertThat(gogAuthService.getAccessToken()).isEqualTo("someAccessToken");
+            assertThat(gogAuthService.getAccessToken()).isEqualTo(gogAuthResponse.getAccessToken());
         }
 
         @Test
-        void shouldThrowGivenTokenIsNull() {
+        void shouldThrowGivenNotAuthenticated() {
             assertThatThrownBy(() -> gogAuthService.getAccessToken())
                     .isInstanceOf(GogAuthException.class)
                     .hasMessageContaining("must authenticate");
         }
 
         @Test
-        void shouldThrowGivenTokenIsExpired() {
-            authenticateCorrectly(-1);
+        void shouldThrowGivenAccessTokenIsExpiredOnBoundary() {
+            GogAuthenticationResponse gogAuthResponse = TestGogAuthenticationResponse.valid();
+            authenticateCorrectly(gogAuthResponse);
+            clock.moveForward(Duration.ofSeconds(gogAuthResponse.getExpiresIn()));
+
+            assertThatThrownBy(() -> gogAuthService.getAccessToken())
+                    .isInstanceOf(GogAuthException.class)
+                    .hasMessageContaining("Access token expired");
+        }
+
+        @Test
+        void shouldThrowGivenAccessTokenIsExpiredBeyondBoundary() {
+            GogAuthenticationResponse gogAuthResponse = TestGogAuthenticationResponse.valid();
+            authenticateCorrectly(gogAuthResponse);
+            clock.moveForward(Duration.ofSeconds(gogAuthResponse.getExpiresIn() + 1));
+
             assertThatThrownBy(() -> gogAuthService.getAccessToken())
                     .isInstanceOf(GogAuthException.class)
                     .hasMessageContaining("Access token expired");
@@ -121,8 +133,8 @@ class GogAuthSpringServiceTest {
     class GetRefreshToken {
 
         @Test
-        void shouldGetRefreshToken() {
-            authenticateCorrectly(3600);
+        void shouldGetRefreshTokenGivenAuthenticated() {
+            authenticateCorrectly(TestGogAuthenticationResponse.valid());
 
             assertThat(gogAuthService.getRefreshToken()).isEqualTo("someRefreshToken");
         }
@@ -148,7 +160,8 @@ class GogAuthSpringServiceTest {
 
         @Test
         void shouldNotRefreshAccessTokenGivenNotNeeded() {
-            authenticateCorrectly(3600);
+            GogAuthenticationResponse gogAuthResponse = TestGogAuthenticationResponse.valid();
+            authenticateCorrectly(gogAuthResponse);
 
             gogAuthService.refreshAccessTokenIfNeeded();
 
@@ -157,18 +170,21 @@ class GogAuthSpringServiceTest {
         }
 
         @Test
-        void shouldRefreshAccessTokenGivenNeeded() {
-            authenticateCorrectly(-1);
-
-            var gogAuthResponseRefreshed = new GogAuthenticationResponse("someAccessToken",
-                    "someRefreshToken", 3600, "someSessionId", "someUserId");
-
-            when(gogAuthClient.refreshToken("someRefreshToken"))
-                    .thenReturn(gogAuthResponseRefreshed);
+        void shouldRefreshAccessTokenGivenExactlyHalfwayToExpiry() {
+            GogAuthenticationResponse gogAuthResponseInitial = TestGogAuthenticationResponse.validBuilder()
+                    .withAccessToken("initialAccessToken")
+                    .withExpiresIn(2) // Easily divisible by 2
+                    .build();
+            GogAuthenticationResponse gogAuthResponseRefreshed = TestGogAuthenticationResponse.validBuilder()
+                    .withAccessToken("refreshedAccessToken")
+                    .build();
+            authenticateCorrectly(gogAuthResponseInitial);
+            tokenCanBeRefreshed(gogAuthResponseInitial.getRefreshToken(), gogAuthResponseRefreshed);
+            clock.moveForward(Duration.ofSeconds(gogAuthResponseInitial.getExpiresIn() / 2));
 
             gogAuthService.refreshAccessTokenIfNeeded();
 
-            assertThat(gogAuthService.isAuthenticated()).isTrue();
+            assertThat(gogAuthService.getAccessToken()).isEqualTo(gogAuthResponseRefreshed.getAccessToken());
         }
     }
 
@@ -177,7 +193,7 @@ class GogAuthSpringServiceTest {
 
         @Test
         void shouldLogOut() {
-            authenticateCorrectly(3600);
+            authenticateCorrectly(TestGogAuthenticationResponse.valid());
 
             gogAuthService.logOut();
 

--- a/backend/src/test/java/dev/codesoapbox/backity/gameproviders/gog/infrastructure/adapters/driven/api/spring/auth/model/remote/TestGogAuthenticationResponse.java
+++ b/backend/src/test/java/dev/codesoapbox/backity/gameproviders/gog/infrastructure/adapters/driven/api/spring/auth/model/remote/TestGogAuthenticationResponse.java
@@ -1,0 +1,45 @@
+package dev.codesoapbox.backity.gameproviders.gog.infrastructure.adapters.driven.api.spring.auth.model.remote;
+
+import lombok.Builder;
+
+@Builder(builderClassName = "Builder", builderMethodName = "", buildMethodName = "internalBuild", setterPrefix = "with")
+public class TestGogAuthenticationResponse {
+
+    @lombok.Builder.Default
+    private String accessToken = "someAccessToken";
+
+    @lombok.Builder.Default
+    private String refreshToken = "someRefreshToken";
+
+    @lombok.Builder.Default
+    private Integer expiresIn = 3600;
+
+    @lombok.Builder.Default
+    private String sessionId = "someSessionId";
+
+    @lombok.Builder.Default
+    private String userId = "someUserId";
+
+    public static GogAuthenticationResponse valid() {
+        return validBuilder().build();
+    }
+
+    public static Builder validBuilder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+
+        public GogAuthenticationResponse build() {
+            TestGogAuthenticationResponse temp = internalBuild();
+
+            return new GogAuthenticationResponse(
+                    temp.accessToken,
+                    temp.refreshToken,
+                    temp.expiresIn,
+                    temp.sessionId,
+                    temp.userId
+            );
+        }
+    }
+}

--- a/backend/src/test/java/dev/codesoapbox/backity/gameproviders/gog/infrastructure/adapters/driven/api/spring/embed/GogFileBackupServiceTest.java
+++ b/backend/src/test/java/dev/codesoapbox/backity/gameproviders/gog/infrastructure/adapters/driven/api/spring/embed/GogFileBackupServiceTest.java
@@ -61,12 +61,26 @@ class GogFileBackupServiceTest {
 
         @Test
         void shouldReturnTrueGivenConnected() {
+            isConnected();
+
+            assertThat(gogFileBackupService.isConnected()).isTrue();
+        }
+
+        private void isConnected() {
             when(authService.isAuthenticated())
-                    .thenReturn(false)
                     .thenReturn(true);
+        }
+
+        @Test
+        void shouldReturnFalseGivenNotConnected() {
+            isNotConnected();
 
             assertThat(gogFileBackupService.isConnected()).isFalse();
-            assertThat(gogFileBackupService.isConnected()).isTrue();
+        }
+
+        private void isNotConnected() {
+            when(authService.isAuthenticated())
+                    .thenReturn(false);
         }
     }
 

--- a/backend/src/test/java/dev/codesoapbox/backity/gameproviders/gog/infrastructure/adapters/driven/api/spring/embed/webclient/GogEmbedWebClientIT.java
+++ b/backend/src/test/java/dev/codesoapbox/backity/gameproviders/gog/infrastructure/adapters/driven/api/spring/embed/webclient/GogEmbedWebClientIT.java
@@ -55,13 +55,17 @@ class GogEmbedWebClientIT {
         @Test
         void shouldDelegateToOperation() {
             String gameId = "someGameId";
-            Optional<GogGameWithFiles> expectedResult = Optional.of(mock(GogGameWithFiles.class));
-            when(getGameDetailsOperation.execute(gameId))
-                    .thenReturn(expectedResult);
+            GogGameWithFiles expectedResult = mock(GogGameWithFiles.class);
+            getGameDetailsOperationExecutes(gameId, expectedResult);
 
             Optional<GogGameWithFiles> result = gogEmbedClient.getGameDetails(gameId);
 
-            assertThat(result).isEqualTo(expectedResult);
+            assertThat(result).get().isEqualTo(expectedResult);
+        }
+
+        private void getGameDetailsOperationExecutes(String gameId, GogGameWithFiles expectedResult) {
+            when(getGameDetailsOperation.execute(gameId))
+                    .thenReturn(Optional.of(expectedResult));
         }
     }
 
@@ -71,12 +75,16 @@ class GogEmbedWebClientIT {
         @Test
         void shouldDelegateToOperation() {
             String expectedResult = "10 GB";
-            when(getLibrarySizeOperation.execute())
-                    .thenReturn(expectedResult);
+            getLibrarySizeOperationExecutes(expectedResult);
 
             String result = gogEmbedClient.getLibrarySize();
 
             assertThat(result).isEqualTo(expectedResult);
+        }
+
+        private void getLibrarySizeOperationExecutes(String expectedResult) {
+            when(getLibrarySizeOperation.execute())
+                    .thenReturn(expectedResult);
         }
     }
 
@@ -86,12 +94,16 @@ class GogEmbedWebClientIT {
         @Test
         void shouldDelegateToOperation() {
             List<String> expectedResult = List.of("1", "2", "3");
-            when(getLibraryGameIdsOperation.execute())
-                    .thenReturn(expectedResult);
+            getLibraryGameIdsOperationExecutes(expectedResult);
 
             List<String> result = gogEmbedClient.getLibraryGameIds();
 
             assertThat(result).isEqualTo(expectedResult);
+        }
+
+        private void getLibraryGameIdsOperationExecutes(List<String> expectedResult) {
+            when(getLibraryGameIdsOperation.execute())
+                    .thenReturn(expectedResult);
         }
     }
 
@@ -103,13 +115,19 @@ class GogEmbedWebClientIT {
             SourceFile sourceFile = mock(SourceFile.class);
             OutputStreamProgressTracker progress = mock(OutputStreamProgressTracker.class);
             DataBufferFluxTrackableFileStream expectedResult = mock(DataBufferFluxTrackableFileStream.class);
-            when(initializeProgressAndStreamFileOperation.execute(sourceFile, progress))
-                    .thenReturn(expectedResult);
+            initializeProgressAndStreamFileOperationExecutes(sourceFile, progress, expectedResult);
 
             DataBufferFluxTrackableFileStream result = gogEmbedClient
                     .initializeProgressAndStreamFile(sourceFile, progress);
 
             assertThat(result).isEqualTo(expectedResult);
+        }
+
+        private void initializeProgressAndStreamFileOperationExecutes(
+                SourceFile sourceFile, OutputStreamProgressTracker progress,
+                DataBufferFluxTrackableFileStream expectedResult) {
+            when(initializeProgressAndStreamFileOperation.execute(sourceFile, progress))
+                    .thenReturn(expectedResult);
         }
     }
 }

--- a/backend/src/test/java/dev/codesoapbox/backity/gameproviders/gog/infrastructure/adapters/driving/api/http/controllers/AuthenticateGogControllerIT.java
+++ b/backend/src/test/java/dev/codesoapbox/backity/gameproviders/gog/infrastructure/adapters/driving/api/http/controllers/AuthenticateGogControllerIT.java
@@ -31,9 +31,7 @@ class AuthenticateGogControllerIT {
                     "refresh_token": "%s"
                 }
                 """.formatted(refreshToken);
-
-        when(useCase.execute(code))
-                .thenReturn(refreshToken);
+        authenticationSucceeds(code, refreshToken);
 
         mockMvc.perform(post("/api/" + GogAuthRestResource.RESOURCE_URL)
                         .contentType(MediaType.APPLICATION_JSON)
@@ -46,5 +44,10 @@ class AuthenticateGogControllerIT {
                 .andDo(print())
                 .andExpect(status().isOk())
                 .andExpect(content().json(expectedJson));
+    }
+
+    private void authenticationSucceeds(String code, String refreshToken) {
+        when(useCase.execute(code))
+                .thenReturn(refreshToken);
     }
 }

--- a/backend/src/test/java/dev/codesoapbox/backity/gameproviders/gog/infrastructure/adapters/driving/api/http/controllers/GetGogAuthenticationStatusControllerIT.java
+++ b/backend/src/test/java/dev/codesoapbox/backity/gameproviders/gog/infrastructure/adapters/driving/api/http/controllers/GetGogAuthenticationStatusControllerIT.java
@@ -23,12 +23,16 @@ class GetGogAuthenticationStatusControllerIT {
 
     @Test
     void shouldCheckAuthentication() throws Exception {
-        when(useCase.execute())
-                .thenReturn(true);
+        isAuthenticated();
 
         mockMvc.perform(get("/api/" + GogAuthRestResource.RESOURCE_URL))
                 .andDo(print())
                 .andExpect(status().isOk())
                 .andExpect(content().string("true"));
+    }
+
+    private void isAuthenticated() {
+        when(useCase.execute())
+                .thenReturn(true);
     }
 }

--- a/backend/src/test/java/dev/codesoapbox/backity/gameproviders/gog/infrastructure/adapters/driving/api/http/controllers/GetGogConfigControllerIT.java
+++ b/backend/src/test/java/dev/codesoapbox/backity/gameproviders/gog/infrastructure/adapters/driving/api/http/controllers/GetGogConfigControllerIT.java
@@ -24,8 +24,8 @@ class GetGogConfigControllerIT {
 
     @Test
     void shouldGetGogConfig() throws Exception {
-        when(useCase.execute())
-                .thenReturn(new GogConfigInfo("someUserAuthUrl"));
+        GogConfigInfo gogConfigInfo = new GogConfigInfo("someUserAuthUrl");
+        exists(gogConfigInfo);
 
         String expectedResponseJson = """
                 {
@@ -36,5 +36,10 @@ class GetGogConfigControllerIT {
                 .andDo(print())
                 .andExpect(status().isOk())
                 .andExpect(content().json(expectedResponseJson));
+    }
+
+    private void exists(GogConfigInfo gogConfigInfo) {
+        when(useCase.execute())
+                .thenReturn(gogConfigInfo);
     }
 }

--- a/backend/src/test/java/dev/codesoapbox/backity/gameproviders/gog/infrastructure/adapters/driving/api/http/controllers/GetGogGameWithFilesControllerIT.java
+++ b/backend/src/test/java/dev/codesoapbox/backity/gameproviders/gog/infrastructure/adapters/driving/api/http/controllers/GetGogGameWithFilesControllerIT.java
@@ -61,9 +61,7 @@ class GetGogGameWithFilesControllerIT {
                 )),
                 "someChangelog"
         );
-
-        when(useCase.execute(gameId))
-                .thenReturn(Optional.of(gogGameDetails));
+        gameExists(gameId, gogGameDetails);
 
         mockMvc.perform(get("/api/gog/games/" + gameId))
                 .andDo(print())
@@ -71,15 +69,23 @@ class GetGogGameWithFilesControllerIT {
                 .andExpect(content().json(expectedResponse));
     }
 
+    private void gameExists(String gameId, GogGameWithFiles gogGameDetails) {
+        when(useCase.execute(gameId))
+                .thenReturn(Optional.of(gogGameDetails));
+    }
+
     @Test
     void shouldReturnHttp404GivenGameDetailsNotFound() throws Exception {
         var gameId = "someGameId";
-
-        when(useCase.execute(gameId))
-                .thenReturn(Optional.empty());
+        gameDoesNotExist(gameId);
 
         mockMvc.perform(get("/api/gog/games/" + gameId))
                 .andDo(print())
                 .andExpect(status().isNotFound());
+    }
+
+    private void gameDoesNotExist(String gameId) {
+        when(useCase.execute(gameId))
+                .thenReturn(Optional.empty());
     }
 }

--- a/backend/src/test/java/dev/codesoapbox/backity/gameproviders/gog/infrastructure/adapters/driving/api/http/controllers/GetGogLibrarySizeControllerIT.java
+++ b/backend/src/test/java/dev/codesoapbox/backity/gameproviders/gog/infrastructure/adapters/driving/api/http/controllers/GetGogLibrarySizeControllerIT.java
@@ -24,12 +24,16 @@ class GetGogLibrarySizeControllerIT {
     @Test
     void shouldGetLibrarySize() throws Exception {
         String expectedSize = "1GB";
-        when(useCase.execute())
-                .thenReturn(expectedSize);
+        librarySizeIs(expectedSize);
 
         mockMvc.perform(get("/api/gog/library/size"))
                 .andDo(print())
                 .andExpect(status().isOk())
                 .andExpect(content().string(expectedSize));
+    }
+
+    private void librarySizeIs(String expectedSize) {
+        when(useCase.execute())
+                .thenReturn(expectedSize);
     }
 }

--- a/backend/src/test/java/dev/codesoapbox/backity/gameproviders/gog/infrastructure/adapters/driving/api/http/controllers/RefreshGogAccessTokenControllerIT.java
+++ b/backend/src/test/java/dev/codesoapbox/backity/gameproviders/gog/infrastructure/adapters/driving/api/http/controllers/RefreshGogAccessTokenControllerIT.java
@@ -31,8 +31,7 @@ class RefreshGogAccessTokenControllerIT {
                     "refresh_token": "%s"
                 }
                 """.formatted(accessToken);
-        when(useCase.execute(refreshToken))
-                .thenReturn(accessToken);
+        useCaseRefreshesToken(refreshToken, accessToken);
 
         mockMvc.perform(put("/api/" + GogAuthRestResource.RESOURCE_URL)
                         .contentType(MediaType.APPLICATION_JSON)
@@ -44,5 +43,10 @@ class RefreshGogAccessTokenControllerIT {
                 .andDo(print())
                 .andExpect(status().isOk())
                 .andExpect(content().json(expectedJson));
+    }
+
+    private void useCaseRefreshesToken(String refreshToken, String accessToken) {
+        when(useCase.execute(refreshToken))
+                .thenReturn(accessToken);
     }
 }

--- a/backend/src/test/java/dev/codesoapbox/backity/shared/infrastructure/adapters/driving/api/http/lowercaseenums/LowercaseEnumFinderTest.java
+++ b/backend/src/test/java/dev/codesoapbox/backity/shared/infrastructure/adapters/driving/api/http/lowercaseenums/LowercaseEnumFinderTest.java
@@ -61,10 +61,7 @@ class LowercaseEnumFinderTest {
 
         @Test
         void shouldReturnEnumsAnnotatedWithLowercaseApiEnum() {
-            when(applicationContext.getBeanNamesForAnnotation(RestController.class))
-                    .thenReturn(new String[]{"testController"});
-            doReturn(TestController.class)
-                    .when(applicationContext).getType("testController");
+            controllerIsRegisteredInApplicationContext();
 
             List<Class<?>> result = enumFinder.getAnnotatedControllerEnums();
 
@@ -72,5 +69,12 @@ class LowercaseEnumFinderTest {
                     .hasSize(2)
                     .hasSameElementsAs(Set.of(TestEnum1.class, TestEnum3.class));
         }
+    }
+
+    private void controllerIsRegisteredInApplicationContext() {
+        when(applicationContext.getBeanNamesForAnnotation(RestController.class))
+                .thenReturn(new String[]{"testController"});
+        doReturn(TestController.class)
+                .when(applicationContext).getType("testController");
     }
 }

--- a/backend/src/test/java/dev/codesoapbox/backity/shared/infrastructure/adapters/driving/api/http/lowercaseenums/openapi/SwaggerEnumLowerCaseModelConverterTest.java
+++ b/backend/src/test/java/dev/codesoapbox/backity/shared/infrastructure/adapters/driving/api/http/lowercaseenums/openapi/SwaggerEnumLowerCaseModelConverterTest.java
@@ -107,11 +107,15 @@ class SwaggerEnumLowerCaseModelConverterTest {
     }
 
     private void mockDelegation(AnnotatedType annotatedType, Schema<?> expectedResult) {
-        when(iterator.hasNext()).thenReturn(true);
         ModelConverter nextModelConverterMock = mock(ModelConverter.class);
-        when(iterator.next()).thenReturn(nextModelConverterMock);
+        nextIteratorValueIs(nextModelConverterMock);
         when(nextModelConverterMock.resolve(annotatedType, modelConverterContext, iterator))
                 .thenReturn(expectedResult);
+    }
+
+    private void nextIteratorValueIs(ModelConverter nextModelConverterMock) {
+        when(iterator.hasNext()).thenReturn(true);
+        when(iterator.next()).thenReturn(nextModelConverterMock);
     }
 
     @Test
@@ -133,13 +137,16 @@ class SwaggerEnumLowerCaseModelConverterTest {
     void shouldReturnNullGivenIteratorEmpty() {
         AnnotatedType annotatedType = getAnnotatedTypeFromArgumentAsSimpleType(
                 "testMethodWithoutEnumWithoutAnnotation", Object.class);
-
-        when(iterator.hasNext()).thenReturn(false);
+        iteratorIsEmpty();
 
         Schema<?> result = modelConverter.resolve(annotatedType, modelConverterContext, iterator);
 
         assertThat(result)
                 .isNull();
+    }
+
+    private void iteratorIsEmpty() {
+        when(iterator.hasNext()).thenReturn(false);
     }
 
     @LowercaseApiEnum

--- a/backend/src/test/java/dev/codesoapbox/backity/shared/infrastructure/config/exceptionhandling/RestExceptionHandlerIT.java
+++ b/backend/src/test/java/dev/codesoapbox/backity/shared/infrastructure/config/exceptionhandling/RestExceptionHandlerIT.java
@@ -50,7 +50,7 @@ class RestExceptionHandlerIT {
 
     @Test
     void shouldHandleGeneralErrors() throws Exception {
-        when(testController.testEndpoint()).thenThrow(new RuntimeException());
+        testEndpointThrows(new RuntimeException());
 
         mockMvc.perform(get("/"))
                 .andExpect(status().isInternalServerError())
@@ -60,7 +60,7 @@ class RestExceptionHandlerIT {
     @Test
     void shouldHandleDomainInvariantViolationExceptionsWithNoCause() throws Exception {
         String expectedMessage = "Domain error message";
-        when(testController.testEndpoint()).thenThrow(new DomainInvariantViolationException(expectedMessage));
+        testEndpointThrows(new DomainInvariantViolationException(expectedMessage));
 
         mockMvc.perform(get("/"))
                 .andExpect(status().isUnprocessableContent())
@@ -70,19 +70,23 @@ class RestExceptionHandlerIT {
     @Test
     void shouldHandleDomainInvariantViolationExceptionsWithCause() throws Exception {
         String expectedMessage = "Domain error message";
-        when(testController.testEndpoint())
-                .thenThrow(new DomainInvariantViolationException(expectedMessage, new RuntimeException()));
+        testEndpointThrows(new DomainInvariantViolationException(expectedMessage, new RuntimeException()));
 
         mockMvc.perform(get("/"))
                 .andExpect(status().isUnprocessableContent())
                 .andExpect(jsonPath("$.message").value(expectedMessage));
     }
 
+    private void testEndpointThrows(Throwable exception)
+            throws MethodArgumentNotValidException {
+        when(testController.testEndpoint())
+                .thenThrow(exception);
+    }
+
     @Test
     void shouldHandleDomainInvariantViolationExceptionsWithNoCauseWithMessageKeys() throws Exception {
         var expectedException = new FileCopyNotBackedUpException(FileCopyId.newInstance());
-        when(testController.testEndpoint())
-                .thenThrow(expectedException);
+        testEndpointThrows(expectedException);
 
         mockMvc.perform(get("/"))
                 .andExpect(status().isUnprocessableContent())
@@ -93,7 +97,7 @@ class RestExceptionHandlerIT {
     @Test
     void shouldHandleDomainInvariantViolationExceptionsWithCauseWithMessageKeys() throws Exception {
         String expectedMessage = "Domain error message";
-        when(testController.testEndpoint()).thenThrow(new DomainInvariantViolationException(expectedMessage,
+        testEndpointThrows(new DomainInvariantViolationException(expectedMessage,
                 new FileCopyNotBackedUpException(FileCopyId.newInstance())));
 
         mockMvc.perform(get("/"))
@@ -105,7 +109,7 @@ class RestExceptionHandlerIT {
     @Test
     void shouldHandleIllegalArgumentExceptions() throws Exception {
         String expectedMessage = "Test message";
-        when(testController.testEndpoint()).thenThrow(new IllegalArgumentException(expectedMessage));
+        testEndpointThrows(new IllegalArgumentException(expectedMessage));
 
         mockMvc.perform(get("/"))
                 .andExpect(status().isBadRequest())
@@ -114,7 +118,7 @@ class RestExceptionHandlerIT {
 
     @Test
     void shouldHandleOptimisticLockExceptions() throws Exception {
-        when(testController.testEndpoint()).thenThrow(new OptimisticLockException());
+        testEndpointThrows(new OptimisticLockException());
 
         String expectedMessage = "The resource has been modified by another user. Please refresh and try again.";
         mockMvc.perform(get("/"))
@@ -124,8 +128,7 @@ class RestExceptionHandlerIT {
 
     @Test
     void shouldHandleObjectOptimisticLockingFailureExceptions() throws Exception {
-        when(testController.testEndpoint()).thenThrow(new ObjectOptimisticLockingFailureException("",
-                new RuntimeException()));
+        testEndpointThrows(new ObjectOptimisticLockingFailureException("", new RuntimeException()));
 
         String expectedMessage = "The resource has been modified by another user. Please refresh and try again.";
         mockMvc.perform(get("/"))
@@ -135,18 +138,14 @@ class RestExceptionHandlerIT {
 
     @Test
     void shouldHandleMethodArgumentNotValidExceptions() throws Exception {
-        BindingResult bindingResult = mock(BindingResult.class);
-        when(bindingResult.getAllErrors()).thenReturn(List.of(
+        List<ObjectError> bindingResultErrors = List.of(
                 new ObjectError("objectName1", "defaultMessage1"),
                 new FieldError("objectName2", "field2", "defaultMessage2")
-        ));
-        MethodParameter methodParameter = mock(MethodParameter.class);
+        );
+        BindingResult bindingResult = aBindingResultWithErrors(bindingResultErrors);
+        MethodParameter methodParameter = aMethodParameterWithExecutable();
 
-        // Can't mock Executable.class so just use anything as a stand-in:
-        when(methodParameter.getExecutable()).thenReturn(this.getClass().getDeclaredConstructor());
-
-        when(testController.testEndpoint()).thenThrow(new MethodArgumentNotValidException(
-                methodParameter, bindingResult));
+        testEndpointThrows(new MethodArgumentNotValidException(methodParameter, bindingResult));
 
         mockMvc.perform(get("/"))
                 .andExpect(status().isBadRequest())
@@ -154,6 +153,20 @@ class RestExceptionHandlerIT {
                 .andExpect(jsonPath("$[0].message").value("defaultMessage1"))
                 .andExpect(jsonPath("$[1].fieldName").value("field2"))
                 .andExpect(jsonPath("$[1].message").value("defaultMessage2"));
+    }
+
+    private BindingResult aBindingResultWithErrors(List<ObjectError> bindingResultErrors) {
+        BindingResult bindingResult = mock(BindingResult.class);
+        when(bindingResult.getAllErrors()).thenReturn(bindingResultErrors);
+        return bindingResult;
+    }
+
+    private MethodParameter aMethodParameterWithExecutable() throws NoSuchMethodException {
+        MethodParameter methodParameter = mock(MethodParameter.class);
+
+        // Can't mock Executable.class so just use anything as a stand-in:
+        when(methodParameter.getExecutable()).thenReturn(this.getClass().getDeclaredConstructor());
+        return methodParameter;
     }
 
     @RestController


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Authentication now uses an injected clock and treats tokens expiring at the current time as expired, improving token validity handling.

* **New Features**
  * Added a test-time enforcement that detects and flags direct mocking/stubbing inside test lifecycle methods to prevent fragile tests.

* **Tests**
  * Large-scale refactor extracting repeated setup into reusable helpers, improving readability and maintainability.
  * Added a reusable authentication test fixture for easier auth-related tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->