### PR TITLE
feat: Reserve file paths in UniqueFilePathResolver to ensure uniqueness among concurrent backups

### DIFF
--- a/backend/src/main/java/dev/codesoapbox/backity/core/backup/application/FileBackupService.java
+++ b/backend/src/main/java/dev/codesoapbox/backity/core/backup/application/FileBackupService.java
@@ -8,6 +8,7 @@ import dev.codesoapbox.backity.core.filecopy.domain.FileCopyFailureReason;
 import dev.codesoapbox.backity.core.filecopy.domain.FileCopyRepository;
 import dev.codesoapbox.backity.core.sourcefile.domain.SourceFile;
 import dev.codesoapbox.backity.core.storagesolution.domain.FilePath;
+import dev.codesoapbox.backity.core.storagesolution.domain.FilePathReservation;
 import dev.codesoapbox.backity.core.storagesolution.domain.StorageSolution;
 import dev.codesoapbox.backity.core.storagesolution.domain.UniqueFilePathResolver;
 import lombok.RequiredArgsConstructor;
@@ -51,11 +52,14 @@ public class FileBackupService {
     @SuppressWarnings("java:S1166") // Intentionally suppressing FileWriteWasCanceledException
     private void tryToBackUp(FileCopy fileCopy, SourceFile sourceFile, BackupTarget backupTarget,
                              StorageSolution storageSolution) {
-        FilePath filePath = uniqueFilePathResolver.resolve(
-                backupTarget.getPathTemplate(), sourceFile, storageSolution);
-        markInProgress(fileCopy, filePath);
-
-        try {
+        /*
+        Note that the file path is only guaranteed to be unique within this replication process.
+        If the replication fails, a new file path MUST be resolved, as the UniqueFilePathResolver
+        does not verify against persisted file paths stored in the database.
+         */
+        try (FilePathReservation filePathReservation = uniqueFilePathResolver.resolve(
+                backupTarget.getPathTemplate(), sourceFile, storageSolution)) {
+            markInProgress(fileCopy, filePathReservation.get());
             fileCopyReplicator.replicate(storageSolution, sourceFile, fileCopy);
         } catch (FileWriteWasCanceledException _) {
             storageSolution.deleteIfExists(fileCopy.getFilePath());

--- a/backend/src/main/java/dev/codesoapbox/backity/core/backup/application/StorageSolutionWriteService.java
+++ b/backend/src/main/java/dev/codesoapbox/backity/core/backup/application/StorageSolutionWriteService.java
@@ -19,11 +19,8 @@ import java.util.concurrent.ConcurrentHashMap;
 @RequiredArgsConstructor
 public class StorageSolutionWriteService {
 
-    /// [UniqueFilePathResolver] can only check for uniqueness against files which already exist, and therefore
-    /// cannot guarantee currently active backups are unique amongst themselves
-    /// (as their files may not exist at the time of validation).
-    ///
-    /// This map can be used to ensure multiple active backups are not writing to the same file at the same time.
+    /// [UniqueFilePathResolver] should already guarantee active backups are unique among themselves.
+    /// This acts as a second layer of protection.
     ///
     /// Warning! This alone is not enough to protect against overwriting existing files
     /// if multiple instances of this application are running.

--- a/backend/src/main/java/dev/codesoapbox/backity/core/storagesolution/domain/FilePathReservation.java
+++ b/backend/src/main/java/dev/codesoapbox/backity/core/storagesolution/domain/FilePathReservation.java
@@ -1,0 +1,14 @@
+package dev.codesoapbox.backity.core.storagesolution.domain;
+
+/// Represents a reserved unique file path for a file which might not exist yet.
+///
+/// Solves the problem of ensuring uniqueness of file paths among in-progress backups.
+///
+/// Must be closed after the file is created to free up memory.
+public interface FilePathReservation extends AutoCloseable {
+
+    FilePath get();
+
+    @Override
+    void close();
+}

--- a/backend/src/main/java/dev/codesoapbox/backity/core/storagesolution/domain/UniqueFilePathResolver.java
+++ b/backend/src/main/java/dev/codesoapbox/backity/core/storagesolution/domain/UniqueFilePathResolver.java
@@ -1,19 +1,58 @@
 package dev.codesoapbox.backity.core.storagesolution.domain;
 
+import dev.codesoapbox.backity.DoNotMutate;
 import dev.codesoapbox.backity.core.backuptarget.domain.PathTemplate;
 import dev.codesoapbox.backity.core.sourcefile.domain.SourceFile;
 import dev.codesoapbox.backity.core.storagesolution.domain.exceptions.CouldNotResolveUniqueFilePathException;
+import lombok.EqualsAndHashCode;
+import lombok.RequiredArgsConstructor;
 
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+
+/// Provides file paths which are unique within a storage solution at the time of resolution.
+///
+/// Prevents the same path from being resolved multiple times concurrently by temporarily reserving resolved paths
+/// until the returned [FilePathReservation] is closed.
+///
+/// # Concurrency warning
+///
+/// File path reservations are maintained in memory. Therefore, uniqueness cannot be guaranteed
+/// across multiple instances of this class or multiple instances of the application.
 public class UniqueFilePathResolver {
 
     private static final int MAX_ATTEMPTS = 1000;
+
+    // Ensures that the same file path is not resolved multiple times concurrently
+    private final Set<IdentifiableFilePathReservation> filePathReservations = new HashSet<>();
+
+    /*
+    The current implementation of resolve() only reserves the file path at the very end.
+    To be truly thread-safe, resolve() would need to be changed so that each candidate file path
+    is preemptively reserved. Otherwise, two different resolve() calls might resolve to the same path.
+
+    Given the low frequency of calls to resolve(), it was easier to just add a ReentrantLock to ensure path resolution
+    happens sequentially.
+     */
+    private final Lock reservationLock = new ReentrantLock();
 
     /*
     Warning! This alone is not enough to ensure uniqueness if files are backed up concurrently.
     In that case, two or more files might resolve to the same path, as neither exists in the storage solution yet.
      */
-    public FilePath resolve(PathTemplate pathTemplate, SourceFile sourceFile, StorageSolution storageSolution) {
-        return constructPathUntilUnique(pathTemplate, sourceFile, storageSolution);
+    @DoNotMutate // I was unable to figure out how to test concurrency on this class
+    public FilePathReservation resolve(
+            PathTemplate pathTemplate, SourceFile sourceFile, StorageSolution storageSolution) {
+        reservationLock.lock();
+
+        try {
+            FilePath filePath = constructPathUntilUnique(pathTemplate, sourceFile, storageSolution);
+            return reserve(filePath, storageSolution);
+        } finally {
+            reservationLock.unlock();
+        }
     }
 
     private FilePath constructPathUntilUnique(PathTemplate pathTemplate, SourceFile sourceFile,
@@ -28,8 +67,37 @@ public class UniqueFilePathResolver {
             }
 
             filePath = pathTemplate.constructPath(sourceFile, storageSolution.getSeparator(), attemptNumber);
-        } while (storageSolution.fileExists(filePath));
+        } while (filePathIsReserved(storageSolution, filePath) || storageSolution.fileExists(filePath));
 
         return filePath;
+    }
+
+    private boolean filePathIsReserved(StorageSolution storageSolution, FilePath filePath) {
+        return filePathReservations.contains(new IdentifiableFilePathReservation(filePath, storageSolution.getId()));
+    }
+
+    private FilePathReservation reserve(FilePath filePath, StorageSolution storageSolution) {
+        var reservation = new IdentifiableFilePathReservation(filePath, storageSolution.getId());
+        filePathReservations.add(reservation);
+
+        return reservation;
+    }
+
+    @RequiredArgsConstructor
+    @EqualsAndHashCode
+    private final class IdentifiableFilePathReservation implements FilePathReservation {
+
+        private final FilePath filePath;
+        private final StorageSolutionId storageSolutionId;
+
+        @Override
+        public FilePath get() {
+            return filePath;
+        }
+
+        @Override
+        public void close() {
+            filePathReservations.remove(this);
+        }
     }
 }

--- a/backend/src/test/java/dev/codesoapbox/backity/core/backup/application/FileBackupServiceTest.java
+++ b/backend/src/test/java/dev/codesoapbox/backity/core/backup/application/FileBackupServiceTest.java
@@ -7,14 +7,12 @@ import dev.codesoapbox.backity.core.filecopy.domain.FileCopyFailureReason;
 import dev.codesoapbox.backity.core.filecopy.domain.FileCopyRepository;
 import dev.codesoapbox.backity.core.filecopy.domain.FileCopyStatus;
 import dev.codesoapbox.backity.core.sourcefile.domain.SourceFile;
-import dev.codesoapbox.backity.core.storagesolution.domain.FakeUnixStorageSolution;
-import dev.codesoapbox.backity.core.storagesolution.domain.FilePath;
-import dev.codesoapbox.backity.core.storagesolution.domain.StorageSolution;
-import dev.codesoapbox.backity.core.storagesolution.domain.UniqueFilePathResolver;
+import dev.codesoapbox.backity.core.storagesolution.domain.*;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -60,7 +58,7 @@ class FileBackupServiceTest {
                     fileBackupContext.backupTarget().getPathTemplate(),
                     fileBackupContext.sourceFile(),
                     fileBackupContext.storageSolution()))
-                    .thenReturn(filePath);
+                    .thenReturn(TestFilePathReservation.of(filePath));
 
             return filePath;
         }
@@ -156,6 +154,59 @@ class FileBackupServiceTest {
         }
 
         @Nested
+        class ReservingFilePaths {
+
+            private FilePathReservation aMockFilePathReservation() {
+                var filePathReservation = mock(FilePathReservation.class);
+                var filePath = new FilePath("someFileDir/someFile");
+                when(filePathReservation.get()).thenReturn(filePath);
+                return filePathReservation;
+            }
+
+            @Test
+            void shouldNotCloseReservationBeforeReplicating() {
+                FileBackupContext fileBackupContext = TestFileBackupContext.enqueuedLocalGog();
+                gameProviderIsConnectedFor(fileBackupContext.sourceFile());
+                FilePathReservation filePathReservation = aMockFilePathReservation();
+                aUniqueFilePathIsResolved(fileBackupContext, filePathReservation);
+
+                fileBackupService.backUpFile(fileBackupContext);
+
+                InOrder inOrder = inOrder(fileCopyReplicator, filePathReservation);
+                inOrder.verify(fileCopyReplicator).replicate(any(), any(), any());
+                inOrder.verify(filePathReservation).close();
+            }
+
+            /*
+             * It's safe to release the reservation immediately after replication, as the file already
+             * exists in the storage solution.
+             */
+            @Test
+            void shouldCloseReservationAfterStoringFileCopy() {
+                FileBackupContext fileBackupContext = TestFileBackupContext.enqueuedLocalGog();
+                gameProviderIsConnectedFor(fileBackupContext.sourceFile());
+                FilePathReservation filePathReservation = aMockFilePathReservation();
+                aUniqueFilePathIsResolved(fileBackupContext, filePathReservation);
+
+                fileBackupService.backUpFile(fileBackupContext);
+
+                InOrder inOrder = inOrder(fileCopyRepository, filePathReservation);
+                inOrder.verify(fileCopyRepository).save(argThat(fileCopy ->
+                        fileCopy.getStatus() == FileCopyStatus.STORED_INTEGRITY_UNKNOWN));
+                inOrder.verify(filePathReservation).close();
+            }
+
+            private void aUniqueFilePathIsResolved(
+                    FileBackupContext fileBackupContext, FilePathReservation filePathReservation) {
+                when(uniqueFilePathResolver.resolve(
+                        fileBackupContext.backupTarget().getPathTemplate(),
+                        fileBackupContext.sourceFile(),
+                        fileBackupContext.storageSolution()
+                )).thenReturn(filePathReservation);
+            }
+        }
+
+        @Nested
         class Canceling {
 
             @Test
@@ -191,7 +242,8 @@ class FileBackupServiceTest {
                 assertThat(storageSolution.fileExists(filePath)).isFalse();
             }
 
-            private void backupIsCanceledDuringReplication(FilePath filePath, FakeUnixStorageSolution storageSolution, FileBackupContext fileBackupContext) {
+            private void backupIsCanceledDuringReplication(
+                    FilePath filePath, FakeUnixStorageSolution storageSolution, FileBackupContext fileBackupContext) {
                 doThrow(new FileWriteWasCanceledException(filePath, storageSolution))
                         .when(fileCopyReplicator).replicate(storageSolution, fileBackupContext.sourceFile(),
                                 fileBackupContext.fileCopy());

--- a/backend/src/test/java/dev/codesoapbox/backity/core/storagesolution/domain/TestFilePathReservation.java
+++ b/backend/src/test/java/dev/codesoapbox/backity/core/storagesolution/domain/TestFilePathReservation.java
@@ -1,0 +1,32 @@
+package dev.codesoapbox.backity.core.storagesolution.domain;
+
+public class TestFilePathReservation {
+
+    public static FilePathReservation of(FilePath filePath) {
+        return new FilePathReservation() {
+            @Override
+            public FilePath get() {
+                return filePath;
+            }
+
+            @Override
+            public void close() {
+                // Do nothing
+            }
+        };
+    }
+
+    public static FilePathReservation withCloseCallback(FilePath filePath, Runnable onClose) {
+        return new FilePathReservation() {
+            @Override
+            public FilePath get() {
+                return filePath;
+            }
+
+            @Override
+            public void close() {
+                onClose.run();
+            }
+        };
+    }
+}

--- a/backend/src/test/java/dev/codesoapbox/backity/core/storagesolution/domain/UniqueFilePathResolverTest.java
+++ b/backend/src/test/java/dev/codesoapbox/backity/core/storagesolution/domain/UniqueFilePathResolverTest.java
@@ -46,11 +46,12 @@ class UniqueFilePathResolverTest {
             var filePath = new FilePath("/test/someGameProviderId/someGameTitle/someFileName.txt");
             fakeUnixFileManager.createFile(filePath);
 
-            FilePath result = uniqueFilePathResolver.resolve(PATH_TEMPLATE, sourceFile, fakeUnixFileManager);
+            try (FilePathReservation result =
+                         uniqueFilePathResolver.resolve(PATH_TEMPLATE, sourceFile, fakeUnixFileManager)) {
+                String expectedPath = "/test/someGameProviderId/someGameTitle/someFileName_1.txt";
 
-            String expectedPath = "/test/someGameProviderId/someGameTitle/someFileName_1.txt";
-
-            assertThat(toUnixPath(result.toString())).isEqualTo(expectedPath);
+                assertThat(toUnixPath(result.get().toString())).isEqualTo(expectedPath);
+            }
         }
 
         @Test
@@ -65,11 +66,13 @@ class UniqueFilePathResolverTest {
             fakeUnixFileManager.createFile(new FilePath(
                     "/test/someGameProviderId/someGameTitle/someFileName_1.txt"));
 
-            FilePath result = uniqueFilePathResolver.resolve(PATH_TEMPLATE, sourceFile, fakeUnixFileManager);
+            try (FilePathReservation result =
+                         uniqueFilePathResolver.resolve(PATH_TEMPLATE, sourceFile, fakeUnixFileManager)) {
 
-            String expectedPath = "/test/someGameProviderId/someGameTitle/someFileName_2.txt";
+                String expectedPath = "/test/someGameProviderId/someGameTitle/someFileName_2.txt";
 
-            assertThat(toUnixPath(result.toString())).isEqualTo(expectedPath);
+                assertThat(toUnixPath(result.get().toString())).isEqualTo(expectedPath);
+            }
         }
 
         @Test
@@ -81,11 +84,13 @@ class UniqueFilePathResolverTest {
                     .build();
             fakeUnixFileManager.createFile(new FilePath("/test/someGameProviderId/someGameTitle/someFileName"));
 
-            FilePath result = uniqueFilePathResolver.resolve(PATH_TEMPLATE, sourceFile, fakeUnixFileManager);
+            try (FilePathReservation result =
+                         uniqueFilePathResolver.resolve(PATH_TEMPLATE, sourceFile, fakeUnixFileManager)) {
 
-            String expectedPath = "/test/someGameProviderId/someGameTitle/someFileName_1";
+                String expectedPath = "/test/someGameProviderId/someGameTitle/someFileName_1";
 
-            assertThat(toUnixPath(result.toString())).isEqualTo(expectedPath);
+                assertThat(toUnixPath(result.get().toString())).isEqualTo(expectedPath);
+            }
         }
 
         @Test
@@ -98,11 +103,13 @@ class UniqueFilePathResolverTest {
             createFileSeveralTimes(999,
                     "/test/someGameProviderId/someGameTitle/someFileName", ".exe");
 
-            FilePath result = uniqueFilePathResolver.resolve(PATH_TEMPLATE, sourceFile, fakeUnixFileManager);
+            try (FilePathReservation result =
+                         uniqueFilePathResolver.resolve(PATH_TEMPLATE, sourceFile, fakeUnixFileManager)) {
 
-            String expectedPath = "/test/someGameProviderId/someGameTitle/someFileName_999.exe";
+                String expectedPath = "/test/someGameProviderId/someGameTitle/someFileName_999.exe";
 
-            assertThat(toUnixPath(result.toString())).isEqualTo(expectedPath);
+                assertThat(toUnixPath(result.get().toString())).isEqualTo(expectedPath);
+            }
         }
 
         @SuppressWarnings("SameParameterValue")
@@ -114,6 +121,45 @@ class UniqueFilePathResolverTest {
             }
         }
 
+        @Test
+        void shouldResolveUniqueFilePathGivenPathIsReserved() {
+            SourceFile sourceFile = TestSourceFile.gogBuilder()
+                    .gameProviderId(new GameProviderId("someGameProviderId"))
+                    .originalGameTitle(new GameTitle("someGameTitle"))
+                    .originalFileName(new FileName("someFileName.exe"))
+                    .build();
+
+            try (var _ = uniqueFilePathResolver.resolve(PATH_TEMPLATE, sourceFile, fakeUnixFileManager)) {
+                try (FilePathReservation result =
+                             uniqueFilePathResolver.resolve(PATH_TEMPLATE, sourceFile, fakeUnixFileManager)) {
+
+                    String expectedPath = "/test/someGameProviderId/someGameTitle/someFileName_1.exe";
+
+                    assertThat(toUnixPath(result.get().toString())).isEqualTo(expectedPath);
+                }
+            }
+        }
+
+        @Test
+        void shouldIgnoreFilePathReservationGivenItIsReleased() {
+            SourceFile sourceFile = TestSourceFile.gogBuilder()
+                    .gameProviderId(new GameProviderId("someGameProviderId"))
+                    .originalGameTitle(new GameTitle("someGameTitle"))
+                    .originalFileName(new FileName("someFileName.exe"))
+                    .build();
+            uniqueFilePathResolver.resolve(PATH_TEMPLATE, sourceFile, fakeUnixFileManager)
+                    .close();
+
+            try (FilePathReservation result =
+                         uniqueFilePathResolver.resolve(PATH_TEMPLATE, sourceFile, fakeUnixFileManager)) {
+
+                String expectedPath = "/test/someGameProviderId/someGameTitle/someFileName.exe";
+
+                assertThat(toUnixPath(result.get().toString())).isEqualTo(expectedPath);
+            }
+        }
+
+        @SuppressWarnings("resource") // Will throw before returning closeable resource
         @Test
         void shouldThrowAfterFailingToFindUniqueFilePathTooManyTimes() {
             SourceFile sourceFile = TestSourceFile.gogBuilder()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a reservation mechanism for destination paths to coordinate backups and avoid conflicts during concurrent operations.
* **Bug Fixes**
  * Improved uniqueness guarantees so backups avoid duplicate destination paths even under concurrent replication and failure/retry scenarios.
* **Tests**
  * Added tests validating reservation lifecycle and behavior under concurrent and failure conditions.
* **Documentation**
  * Clarified comments about uniqueness scope and retry behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->