### PR TITLE
Improve persistence testing tools

### DIFF
--- a/backend/src/test/java/dev/codesoapbox/backity/core/backuptarget/infrastructure/adapters/driven/persistence/jpa/BackupTargetDirectJpaPersistenceStrategy.java
+++ b/backend/src/test/java/dev/codesoapbox/backity/core/backuptarget/infrastructure/adapters/driven/persistence/jpa/BackupTargetDirectJpaPersistenceStrategy.java
@@ -2,22 +2,36 @@ package dev.codesoapbox.backity.core.backuptarget.infrastructure.adapters.driven
 
 import dev.codesoapbox.backity.core.backuptarget.domain.BackupTarget;
 import dev.codesoapbox.backity.testing.jpa.DirectJpaPersistenceStrategy;
+import lombok.RequiredArgsConstructor;
 import org.springframework.boot.jpa.test.autoconfigure.TestEntityManager;
 
-@SuppressWarnings("unused")
+@SuppressWarnings("unused") // Used via component scanning
+@RequiredArgsConstructor
 public class BackupTargetDirectJpaPersistenceStrategy
-        extends DirectJpaPersistenceStrategy<BackupTarget, BackupTargetJpaEntity> {
+        implements DirectJpaPersistenceStrategy<BackupTarget, BackupTargetJpaEntity> {
 
-    public BackupTargetDirectJpaPersistenceStrategy(
-            TestEntityManager entityManager,
-            BackupTargetJpaEntityMapper entityMapper
-    ) {
-        super(
-                entityManager,
-                entityMapper::toEntity,
-                entityMapper::toDomain,
-                (em, obj) -> em.find(BackupTargetJpaEntity.class, obj.getId().value()),
-                BackupTarget.class
+    private final BackupTargetJpaEntityMapper entityMapper;
+
+    @Override
+    public Class<BackupTarget> getDomainObjectClass() {
+        return BackupTarget.class;
+    }
+
+    @Override
+    public BackupTargetJpaEntity toEntity(BackupTarget domainObject) {
+        return entityMapper.toEntity(domainObject);
+    }
+
+    @Override
+    public BackupTarget toDomain(BackupTargetJpaEntity entity) {
+        return entityMapper.toDomain(entity);
+    }
+
+    @Override
+    public BackupTargetJpaEntity findPersistedEntity(TestEntityManager entityManager, BackupTarget domainObject) {
+        return entityManager.find(
+                BackupTargetJpaEntity.class,
+                domainObject.getId().value()
         );
     }
 }

--- a/backend/src/test/java/dev/codesoapbox/backity/core/backuptarget/infrastructure/adapters/driven/persistence/jpa/BackupTargetDirectJpaPersistenceStrategy.java
+++ b/backend/src/test/java/dev/codesoapbox/backity/core/backuptarget/infrastructure/adapters/driven/persistence/jpa/BackupTargetDirectJpaPersistenceStrategy.java
@@ -1,0 +1,23 @@
+package dev.codesoapbox.backity.core.backuptarget.infrastructure.adapters.driven.persistence.jpa;
+
+import dev.codesoapbox.backity.core.backuptarget.domain.BackupTarget;
+import dev.codesoapbox.backity.testing.jpa.DirectJpaPersistenceStrategy;
+import org.springframework.boot.jpa.test.autoconfigure.TestEntityManager;
+
+@SuppressWarnings("unused")
+public class BackupTargetDirectJpaPersistenceStrategy
+        extends DirectJpaPersistenceStrategy<BackupTarget, BackupTargetJpaEntity> {
+
+    public BackupTargetDirectJpaPersistenceStrategy(
+            TestEntityManager entityManager,
+            BackupTargetJpaEntityMapper entityMapper
+    ) {
+        super(
+                entityManager,
+                entityMapper::toEntity,
+                entityMapper::toDomain,
+                (em, obj) -> em.find(BackupTargetJpaEntity.class, obj.getId().value()),
+                BackupTarget.class
+        );
+    }
+}

--- a/backend/src/test/java/dev/codesoapbox/backity/core/backuptarget/infrastructure/adapters/driven/persistence/jpa/BackupTargetJpaRepositoryIT.java
+++ b/backend/src/test/java/dev/codesoapbox/backity/core/backuptarget/infrastructure/adapters/driven/persistence/jpa/BackupTargetJpaRepositoryIT.java
@@ -5,7 +5,7 @@ import dev.codesoapbox.backity.core.backuptarget.domain.BackupTargetId;
 import dev.codesoapbox.backity.core.backuptarget.domain.BackupTargetName;
 import dev.codesoapbox.backity.core.backuptarget.domain.TestBackupTarget;
 import dev.codesoapbox.backity.core.backuptarget.domain.exceptions.BackupTargetNotFoundException;
-import dev.codesoapbox.backity.testing.jpa.TestJpaPersistenceAdapter;
+import dev.codesoapbox.backity.testing.jpa.DirectJpaPersistenceAdapter;
 import dev.codesoapbox.backity.testing.jpa.annotations.MultiDatabaseRepositoryTest;
 import dev.codesoapbox.backity.testing.jpa.extensions.EntityAuditControl;
 import dev.codesoapbox.backity.testing.time.FakeClock;
@@ -34,23 +34,15 @@ abstract class BackupTargetJpaRepositoryIT {
     protected TestEntityManager entityManager;
 
     @Autowired
-    protected BackupTargetJpaEntityMapper entityMapper;
-
-    @Autowired
     protected FakeClock clock;
 
-    private TestJpaPersistenceAdapter<BackupTarget, BackupTargetJpaEntity> backupTargetJpaAdapter;
+    @Autowired
+    private DirectJpaPersistenceAdapter directPersistenceAdapter;
 
     @SuppressWarnings("JUnitMalformedDeclaration")
     @BeforeEach
     void setUp(EntityAuditControl entityAuditControl) {
         entityAuditControl.disable();
-        backupTargetJpaAdapter = new TestJpaPersistenceAdapter<>(
-                entityManager,
-                entityMapper::toEntity,
-                entityMapper::toDomain,
-                (em, obj) -> em.find(BackupTargetJpaEntity.class, obj.getId().value())
-        );
     }
 
     @Test
@@ -60,7 +52,7 @@ abstract class BackupTargetJpaRepositoryIT {
         repository.save(backupTarget);
         entityManager.flush();
 
-        BackupTarget persistedAggregate = backupTargetJpaAdapter.getPersistedDomainObject(backupTarget);
+        BackupTarget persistedAggregate = directPersistenceAdapter.getPersistedDomainObject(backupTarget);
         assertThat(persistedAggregate)
                 .usingRecursiveComparison()
                 .isEqualTo(backupTarget);
@@ -75,14 +67,14 @@ abstract class BackupTargetJpaRepositoryIT {
         repository.save(backupTarget);
         entityManager.flush();
 
-        BackupTarget persistedAggregate = backupTargetJpaAdapter.getPersistedDomainObject(backupTarget);
+        BackupTarget persistedAggregate = directPersistenceAdapter.getPersistedDomainObject(backupTarget);
         assertThat(persistedAggregate)
                 .usingRecursiveComparison()
                 .isEqualTo(backupTarget);
     }
 
     void persistSampleData() {
-        backupTargetJpaAdapter.persist(SampleBackupTargets.getAll());
+        directPersistenceAdapter.persist(SampleBackupTargets.getAll());
     }
 
     @SuppressWarnings("JUnitMalformedDeclaration")
@@ -95,7 +87,7 @@ abstract class BackupTargetJpaRepositoryIT {
         entityManager.flush();
 
         LocalDateTime now = LocalDateTime.now(clock);
-        BackupTarget persistedAggregate = backupTargetJpaAdapter.getPersistedDomainObject(backupTarget);
+        BackupTarget persistedAggregate = directPersistenceAdapter.getPersistedDomainObject(backupTarget);
         assertThat(persistedAggregate.getDateCreated())
                 .isNotEqualTo(backupTarget.getDateCreated())
                 .isEqualTo(now);
@@ -116,7 +108,7 @@ abstract class BackupTargetJpaRepositoryIT {
         entityManager.flush();
 
         LocalDateTime now = LocalDateTime.now(clock);
-        BackupTarget persistedAggregate = backupTargetJpaAdapter.getPersistedDomainObject(backupTarget);
+        BackupTarget persistedAggregate = directPersistenceAdapter.getPersistedDomainObject(backupTarget);
         assertThat(persistedAggregate.getDateCreated())
                 .isEqualTo(backupTarget.getDateCreated())
                 .isNotEqualTo(now);
@@ -156,7 +148,7 @@ abstract class BackupTargetJpaRepositoryIT {
     @Test
     void findAllShouldReturnAllDataForAggregate() {
         BackupTarget backupTarget = SampleBackupTargets.TODAY_LOCAL_FOLDER.get();
-        backupTargetJpaAdapter.persist(backupTarget);
+        directPersistenceAdapter.persist(backupTarget);
 
         List<BackupTarget> result = repository.findAll();
 
@@ -222,7 +214,7 @@ abstract class BackupTargetJpaRepositoryIT {
 
         repository.deleteById(aggregateToDelete.getId());
 
-        assertThat(backupTargetJpaAdapter.exists(aggregateToDelete)).isFalse();
+        assertThat(directPersistenceAdapter.exists(aggregateToDelete)).isFalse();
     }
 
     private static class Time {

--- a/backend/src/test/java/dev/codesoapbox/backity/core/discovery/infrastructure/adapters/driven/persistence/jpa/GameContentDiscoveryResultDirectJpaPersistenceStrategy.java
+++ b/backend/src/test/java/dev/codesoapbox/backity/core/discovery/infrastructure/adapters/driven/persistence/jpa/GameContentDiscoveryResultDirectJpaPersistenceStrategy.java
@@ -1,0 +1,24 @@
+package dev.codesoapbox.backity.core.discovery.infrastructure.adapters.driven.persistence.jpa;
+
+import dev.codesoapbox.backity.core.discovery.domain.GameContentDiscoveryResult;
+import dev.codesoapbox.backity.testing.jpa.DirectJpaPersistenceStrategy;
+import org.springframework.boot.jpa.test.autoconfigure.TestEntityManager;
+
+@SuppressWarnings("unused")
+public class GameContentDiscoveryResultDirectJpaPersistenceStrategy
+        extends DirectJpaPersistenceStrategy<GameContentDiscoveryResult, GameContentDiscoveryResultJpaEntity> {
+
+    public GameContentDiscoveryResultDirectJpaPersistenceStrategy(
+            TestEntityManager entityManager,
+            GameContentDiscoveryResultJpaEntityMapper entityMapper
+    ) {
+        super(
+                entityManager,
+                entityMapper::toEntity,
+                entityMapper::toDomain,
+                (em, obj) ->
+                        em.find(GameContentDiscoveryResultJpaEntity.class, obj.getGameProviderId().value()),
+                GameContentDiscoveryResult.class
+        );
+    }
+}

--- a/backend/src/test/java/dev/codesoapbox/backity/core/discovery/infrastructure/adapters/driven/persistence/jpa/GameContentDiscoveryResultDirectJpaPersistenceStrategy.java
+++ b/backend/src/test/java/dev/codesoapbox/backity/core/discovery/infrastructure/adapters/driven/persistence/jpa/GameContentDiscoveryResultDirectJpaPersistenceStrategy.java
@@ -2,23 +2,37 @@ package dev.codesoapbox.backity.core.discovery.infrastructure.adapters.driven.pe
 
 import dev.codesoapbox.backity.core.discovery.domain.GameContentDiscoveryResult;
 import dev.codesoapbox.backity.testing.jpa.DirectJpaPersistenceStrategy;
+import lombok.RequiredArgsConstructor;
 import org.springframework.boot.jpa.test.autoconfigure.TestEntityManager;
 
-@SuppressWarnings("unused")
+@SuppressWarnings("unused") // Used via component scanning
+@RequiredArgsConstructor
 public class GameContentDiscoveryResultDirectJpaPersistenceStrategy
-        extends DirectJpaPersistenceStrategy<GameContentDiscoveryResult, GameContentDiscoveryResultJpaEntity> {
+        implements DirectJpaPersistenceStrategy<GameContentDiscoveryResult, GameContentDiscoveryResultJpaEntity> {
 
-    public GameContentDiscoveryResultDirectJpaPersistenceStrategy(
-            TestEntityManager entityManager,
-            GameContentDiscoveryResultJpaEntityMapper entityMapper
-    ) {
-        super(
-                entityManager,
-                entityMapper::toEntity,
-                entityMapper::toDomain,
-                (em, obj) ->
-                        em.find(GameContentDiscoveryResultJpaEntity.class, obj.getGameProviderId().value()),
-                GameContentDiscoveryResult.class
+    private final GameContentDiscoveryResultJpaEntityMapper entityMapper;
+
+    @Override
+    public Class<GameContentDiscoveryResult> getDomainObjectClass() {
+        return GameContentDiscoveryResult.class;
+    }
+
+    @Override
+    public GameContentDiscoveryResultJpaEntity toEntity(GameContentDiscoveryResult domainObject) {
+        return entityMapper.toEntity(domainObject);
+    }
+
+    @Override
+    public GameContentDiscoveryResult toDomain(GameContentDiscoveryResultJpaEntity entity) {
+        return entityMapper.toDomain(entity);
+    }
+
+    @Override
+    public GameContentDiscoveryResultJpaEntity findPersistedEntity(
+            TestEntityManager entityManager, GameContentDiscoveryResult domainObject) {
+        return entityManager.find(
+                GameContentDiscoveryResultJpaEntity.class,
+                domainObject.getGameProviderId().value()
         );
     }
 }

--- a/backend/src/test/java/dev/codesoapbox/backity/core/discovery/infrastructure/adapters/driven/persistence/jpa/GameContentDiscoveryResultJpaRepositoryIT.java
+++ b/backend/src/test/java/dev/codesoapbox/backity/core/discovery/infrastructure/adapters/driven/persistence/jpa/GameContentDiscoveryResultJpaRepositoryIT.java
@@ -3,7 +3,7 @@ package dev.codesoapbox.backity.core.discovery.infrastructure.adapters.driven.pe
 import dev.codesoapbox.backity.core.backup.domain.GameProviderId;
 import dev.codesoapbox.backity.core.discovery.domain.GameContentDiscoveryResult;
 import dev.codesoapbox.backity.core.discovery.domain.TestGameContentDiscoveryResult;
-import dev.codesoapbox.backity.testing.jpa.TestJpaPersistenceAdapter;
+import dev.codesoapbox.backity.testing.jpa.DirectJpaPersistenceAdapter;
 import dev.codesoapbox.backity.testing.jpa.annotations.MultiDatabaseRepositoryTest;
 import dev.codesoapbox.backity.testing.jpa.extensions.EntityAuditControl;
 import org.junit.jupiter.api.BeforeEach;
@@ -28,29 +28,17 @@ abstract class GameContentDiscoveryResultJpaRepositoryIT {
     protected TestEntityManager entityManager;
 
     @Autowired
-    protected GameContentDiscoveryResultJpaEntityMapper entityMapper;
-
-    private TestJpaPersistenceAdapter<GameContentDiscoveryResult, GameContentDiscoveryResultJpaEntity>
-            gameContentDiscoveryResultJpaAdapter;
+    private DirectJpaPersistenceAdapter directPersistenceAdapter;
 
     @SuppressWarnings("JUnitMalformedDeclaration")
     @BeforeEach
     void setUp(EntityAuditControl entityAuditControl) {
         entityAuditControl.disable();
-        gameContentDiscoveryResultJpaAdapter = new TestJpaPersistenceAdapter<>(
-                entityManager,
-                entityMapper::toEntity,
-                entityMapper::toDomain,
-                (em, obj) ->
-                        em.find(GameContentDiscoveryResultJpaEntity.class, obj.getGameProviderId().value())
-        );
         persistSampleDependencies();
     }
 
     private void persistSampleDependencies() {
-        for (GameContentDiscoveryResult discoveryResult : SampleDiscoveryResults.getAll()) {
-            entityManager.persist(entityMapper.toEntity(discoveryResult));
-        }
+        directPersistenceAdapter.persist(SampleDiscoveryResults.getAll());
     }
 
     @Test
@@ -63,7 +51,7 @@ abstract class GameContentDiscoveryResultJpaRepositoryIT {
         entityManager.flush();
 
         GameContentDiscoveryResult persistedAggregate =
-                gameContentDiscoveryResultJpaAdapter.getPersistedDomainObject(newDiscoveryResult);
+                directPersistenceAdapter.getPersistedDomainObject(newDiscoveryResult);
         assertThat(persistedAggregate)
                 .usingRecursiveComparison()
                 .isEqualTo(newDiscoveryResult);
@@ -77,7 +65,7 @@ abstract class GameContentDiscoveryResultJpaRepositoryIT {
         entityManager.flush();
 
         GameContentDiscoveryResult persistedResult =
-                gameContentDiscoveryResultJpaAdapter.getPersistedDomainObject(discoveryResult);
+                directPersistenceAdapter.getPersistedDomainObject(discoveryResult);
         assertThat(persistedResult.getGamesDiscovered()).isEqualTo(999);
     }
 

--- a/backend/src/test/java/dev/codesoapbox/backity/core/filecopy/infrastructure/adapters/driven/persistence/jpa/FileCopyDirectJpaPersistenceStrategy.java
+++ b/backend/src/test/java/dev/codesoapbox/backity/core/filecopy/infrastructure/adapters/driven/persistence/jpa/FileCopyDirectJpaPersistenceStrategy.java
@@ -2,21 +2,35 @@ package dev.codesoapbox.backity.core.filecopy.infrastructure.adapters.driven.per
 
 import dev.codesoapbox.backity.core.filecopy.domain.FileCopy;
 import dev.codesoapbox.backity.testing.jpa.DirectJpaPersistenceStrategy;
+import lombok.RequiredArgsConstructor;
 import org.springframework.boot.jpa.test.autoconfigure.TestEntityManager;
 
-@SuppressWarnings("unused")
-public class FileCopyDirectJpaPersistenceStrategy extends DirectJpaPersistenceStrategy<FileCopy, FileCopyJpaEntity> {
+@SuppressWarnings("unused") // Used via component scanning
+@RequiredArgsConstructor
+public class FileCopyDirectJpaPersistenceStrategy implements DirectJpaPersistenceStrategy<FileCopy, FileCopyJpaEntity> {
 
-    public FileCopyDirectJpaPersistenceStrategy(
-            TestEntityManager entityManager,
-            FileCopyJpaEntityMapper entityMapper
-    ) {
-        super(
-                entityManager,
-                entityMapper::toEntity,
-                entityMapper::toDomain,
-                (em, obj) -> em.find(FileCopyJpaEntity.class, obj.getId().value()),
-                FileCopy.class
+    private final FileCopyJpaEntityMapper entityMapper;
+
+    @Override
+    public Class<FileCopy> getDomainObjectClass() {
+        return FileCopy.class;
+    }
+
+    @Override
+    public FileCopyJpaEntity toEntity(FileCopy domainObject) {
+        return entityMapper.toEntity(domainObject);
+    }
+
+    @Override
+    public FileCopy toDomain(FileCopyJpaEntity entity) {
+        return entityMapper.toDomain(entity);
+    }
+
+    @Override
+    public FileCopyJpaEntity findPersistedEntity(TestEntityManager entityManager, FileCopy domainObject) {
+        return entityManager.find(
+                FileCopyJpaEntity.class,
+                domainObject.getId().value()
         );
     }
 }

--- a/backend/src/test/java/dev/codesoapbox/backity/core/filecopy/infrastructure/adapters/driven/persistence/jpa/FileCopyDirectJpaPersistenceStrategy.java
+++ b/backend/src/test/java/dev/codesoapbox/backity/core/filecopy/infrastructure/adapters/driven/persistence/jpa/FileCopyDirectJpaPersistenceStrategy.java
@@ -1,0 +1,22 @@
+package dev.codesoapbox.backity.core.filecopy.infrastructure.adapters.driven.persistence.jpa;
+
+import dev.codesoapbox.backity.core.filecopy.domain.FileCopy;
+import dev.codesoapbox.backity.testing.jpa.DirectJpaPersistenceStrategy;
+import org.springframework.boot.jpa.test.autoconfigure.TestEntityManager;
+
+@SuppressWarnings("unused")
+public class FileCopyDirectJpaPersistenceStrategy extends DirectJpaPersistenceStrategy<FileCopy, FileCopyJpaEntity> {
+
+    public FileCopyDirectJpaPersistenceStrategy(
+            TestEntityManager entityManager,
+            FileCopyJpaEntityMapper entityMapper
+    ) {
+        super(
+                entityManager,
+                entityMapper::toEntity,
+                entityMapper::toDomain,
+                (em, obj) -> em.find(FileCopyJpaEntity.class, obj.getId().value()),
+                FileCopy.class
+        );
+    }
+}

--- a/backend/src/test/java/dev/codesoapbox/backity/core/filecopy/infrastructure/adapters/driven/persistence/jpa/FileCopyJpaRepositoryIT.java
+++ b/backend/src/test/java/dev/codesoapbox/backity/core/filecopy/infrastructure/adapters/driven/persistence/jpa/FileCopyJpaRepositoryIT.java
@@ -4,27 +4,21 @@ import dev.codesoapbox.backity.core.backup.domain.events.FileBackupStartedEvent;
 import dev.codesoapbox.backity.core.backuptarget.domain.BackupTarget;
 import dev.codesoapbox.backity.core.backuptarget.domain.BackupTargetId;
 import dev.codesoapbox.backity.core.backuptarget.domain.TestBackupTarget;
-import dev.codesoapbox.backity.core.backuptarget.infrastructure.adapters.driven.persistence.jpa.BackupTargetJpaEntity;
-import dev.codesoapbox.backity.core.backuptarget.infrastructure.adapters.driven.persistence.jpa.BackupTargetJpaEntityMapper;
 import dev.codesoapbox.backity.core.filecopy.domain.*;
 import dev.codesoapbox.backity.core.filecopy.domain.exceptions.FileCopyNotFoundException;
 import dev.codesoapbox.backity.core.game.domain.Game;
 import dev.codesoapbox.backity.core.game.domain.GameId;
 import dev.codesoapbox.backity.core.game.domain.GameTitle;
-import dev.codesoapbox.backity.core.game.infrastructure.adapters.driven.persistence.jpa.GameJpaEntity;
-import dev.codesoapbox.backity.core.game.infrastructure.adapters.driven.persistence.jpa.GameJpaEntityMapper;
 import dev.codesoapbox.backity.core.sourcefile.domain.SourceFile;
 import dev.codesoapbox.backity.core.sourcefile.domain.SourceFileId;
 import dev.codesoapbox.backity.core.sourcefile.domain.TestSourceFile;
-import dev.codesoapbox.backity.core.sourcefile.infrastructure.adapters.driven.persistence.jpa.SourceFileJpaEntity;
-import dev.codesoapbox.backity.core.sourcefile.infrastructure.adapters.driven.persistence.jpa.SourceFileJpaEntityMapper;
 import dev.codesoapbox.backity.core.storagesolution.domain.FilePath;
 import dev.codesoapbox.backity.shared.domain.DomainEventPublisher;
 import dev.codesoapbox.backity.shared.domain.Page;
 import dev.codesoapbox.backity.shared.domain.Pagination;
 import dev.codesoapbox.backity.shared.infrastructure.adapters.driven.persistence.jpa.SpringPageMapper;
 import dev.codesoapbox.backity.shared.infrastructure.adapters.driven.persistence.jpa.SpringPageableMapper;
-import dev.codesoapbox.backity.testing.jpa.TestJpaPersistenceAdapter;
+import dev.codesoapbox.backity.testing.jpa.DirectJpaPersistenceAdapter;
 import dev.codesoapbox.backity.testing.jpa.annotations.MultiDatabaseRepositoryTest;
 import dev.codesoapbox.backity.testing.jpa.extensions.EntityAuditControl;
 import dev.codesoapbox.backity.testing.time.FakeClock;
@@ -32,7 +26,6 @@ import dev.codesoapbox.backity.testing.time.config.FakeTimeBeanConfig;
 import org.hibernate.exception.ConstraintViolationException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mapstruct.factory.Mappers;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.jpa.test.autoconfigure.TestEntityManager;
 import org.springframework.dao.DataIntegrityViolationException;
@@ -69,39 +62,13 @@ abstract class FileCopyJpaRepositoryIT {
     @Autowired
     protected FakeClock clock;
 
-    private TestJpaPersistenceAdapter<FileCopy, FileCopyJpaEntity> fileCopyJpaAdapter;
-    private TestJpaPersistenceAdapter<Game, GameJpaEntity> gameJpaAdapter;
-    private TestJpaPersistenceAdapter<SourceFile, SourceFileJpaEntity> sourceFileJpaAdapter;
-    private TestJpaPersistenceAdapter<BackupTarget, BackupTargetJpaEntity> backupTargetJpaAdapter;
+    @Autowired
+    private DirectJpaPersistenceAdapter directPersistenceAdapter;
 
     @SuppressWarnings("JUnitMalformedDeclaration")
     @BeforeEach
     void setUp(EntityAuditControl entityAuditControl) {
         entityAuditControl.disable();
-        fileCopyJpaAdapter = new TestJpaPersistenceAdapter<>(
-                entityManager,
-                entityMapper::toEntity,
-                entityMapper::toDomain,
-                (em, obj) -> em.find(FileCopyJpaEntity.class, obj.getId().value())
-        );
-        gameJpaAdapter = new TestJpaPersistenceAdapter<>(
-                entityManager,
-                SampleGames.MAPPER::toEntity,
-                SampleGames.MAPPER::toDomain,
-                (em, obj) -> em.find(GameJpaEntity.class, obj.getId().value())
-        );
-        sourceFileJpaAdapter = new TestJpaPersistenceAdapter<>(
-                entityManager,
-                SampleSourceFiles.MAPPER::toEntity,
-                SampleSourceFiles.MAPPER::toDomain,
-                (em, obj) -> em.find(SourceFileJpaEntity.class, obj.getId().value())
-        );
-        backupTargetJpaAdapter = new TestJpaPersistenceAdapter<>(
-                entityManager,
-                SampleBackupTargets.MAPPER::toEntity,
-                SampleBackupTargets.MAPPER::toDomain,
-                (em, obj) -> em.find(BackupTargetJpaEntity.class, obj.getId().value())
-        );
     }
 
     @Test
@@ -117,16 +84,16 @@ abstract class FileCopyJpaRepositoryIT {
         repository.save(fileCopy);
         entityManager.flush();
 
-        FileCopy persistedAggregate = fileCopyJpaAdapter.getPersistedDomainObject(fileCopy);
+        FileCopy persistedAggregate = directPersistenceAdapter.getPersistedDomainObject(fileCopy);
         assertThat(persistedAggregate)
                 .usingRecursiveComparison()
                 .isEqualTo(fileCopy);
     }
 
     private void persistSampleDependencies() {
-        gameJpaAdapter.persist(SampleGames.getAll());
-        sourceFileJpaAdapter.persist(SampleSourceFiles.getAll());
-        backupTargetJpaAdapter.persist(SampleBackupTargets.getAll());
+        directPersistenceAdapter.persist(SampleGames.getAll());
+        directPersistenceAdapter.persist(SampleSourceFiles.getAll());
+        directPersistenceAdapter.persist(SampleBackupTargets.getAll());
     }
 
     @Test
@@ -138,7 +105,7 @@ abstract class FileCopyJpaRepositoryIT {
         repository.save(fileCopy);
         entityManager.flush();
 
-        FileCopy persistedAggregate = fileCopyJpaAdapter.getPersistedDomainObject(fileCopy);
+        FileCopy persistedAggregate = directPersistenceAdapter.getPersistedDomainObject(fileCopy);
         assertThat(persistedAggregate)
                 .usingRecursiveComparison()
                 .isEqualTo(fileCopy);
@@ -146,7 +113,7 @@ abstract class FileCopyJpaRepositoryIT {
 
     private void persistSampleData() {
         persistSampleDependencies();
-        fileCopyJpaAdapter.persist(SampleFileCopies.getAll());
+        directPersistenceAdapter.persist(SampleFileCopies.getAll());
     }
 
     @SuppressWarnings("JUnitMalformedDeclaration")
@@ -160,7 +127,7 @@ abstract class FileCopyJpaRepositoryIT {
         entityManager.flush();
 
         LocalDateTime now = LocalDateTime.now(clock);
-        FileCopy persistedAggregate = fileCopyJpaAdapter.getPersistedDomainObject(fileCopy);
+        FileCopy persistedAggregate = directPersistenceAdapter.getPersistedDomainObject(fileCopy);
         assertThat(persistedAggregate.getDateCreated())
                 .isNotEqualTo(fileCopy.getDateCreated())
                 .isEqualTo(now);
@@ -181,7 +148,7 @@ abstract class FileCopyJpaRepositoryIT {
         entityManager.flush();
 
         LocalDateTime now = LocalDateTime.now(clock);
-        FileCopy persistedAggregate = fileCopyJpaAdapter.getPersistedDomainObject(fileCopy);
+        FileCopy persistedAggregate = directPersistenceAdapter.getPersistedDomainObject(fileCopy);
         assertThat(persistedAggregate.getDateCreated())
                 .isEqualTo(fileCopy.getDateCreated())
                 .isNotEqualTo(now);
@@ -222,7 +189,7 @@ abstract class FileCopyJpaRepositoryIT {
                 .id(new FileCopyId("09366863-b707-4e5c-8315-ed7e7c56d0a9"))
                 .naturalId(fileCopy1.getNaturalId())
                 .build();
-        fileCopyJpaAdapter.persist(fileCopy1);
+        directPersistenceAdapter.persist(fileCopy1);
 
         repository.save(fileCopy2);
 
@@ -301,7 +268,8 @@ abstract class FileCopyJpaRepositoryIT {
                 .isEqualTo(expectedExisting);
     }
 
-    private void aggregateIsCreatedConcurrently(FileCopySpringRepository mockSpringRepository, FileCopyNaturalId naturalId, FileCopy expectedExisting) {
+    private void aggregateIsCreatedConcurrently(
+            FileCopySpringRepository mockSpringRepository, FileCopyNaturalId naturalId, FileCopy expectedExisting) {
         when(mockSpringRepository.findByNaturalIdSourceFileIdAndNaturalIdBackupTargetId(
                 naturalId.sourceFileId().value(), naturalId.backupTargetId().value()))
                 // Nothing in DB during initial lookup:
@@ -473,8 +441,8 @@ abstract class FileCopyJpaRepositoryIT {
         repository.deleteByBackupTargetIdAndStatusIn(
                 fileCopy.getNaturalId().backupTargetId(), List.of(fileCopy.getStatus()));
 
-        assertThat(fileCopyJpaAdapter.exists(fileCopy)).isFalse();
-        assertThat(fileCopyJpaAdapter.exists(unaffectedFileCopy)).isTrue();
+        assertThat(directPersistenceAdapter.exists(fileCopy)).isFalse();
+        assertThat(directPersistenceAdapter.exists(unaffectedFileCopy)).isTrue();
     }
 
     @Test
@@ -485,7 +453,7 @@ abstract class FileCopyJpaRepositoryIT {
         repository.deleteByBackupTargetIdAndStatusIn(
                 fileCopy.getNaturalId().backupTargetId(), List.of(FileCopyStatus.FAILED));
 
-        assertThat(fileCopyJpaAdapter.exists(fileCopy)).isTrue();
+        assertThat(directPersistenceAdapter.exists(fileCopy)).isTrue();
     }
 
     private static class Time {
@@ -498,8 +466,6 @@ abstract class FileCopyJpaRepositoryIT {
 
     private static class SampleGames {
 
-        public static final GameJpaEntityMapper MAPPER = Mappers.getMapper(GameJpaEntityMapper.class);
-
         public static final Game GAME_1 = anyBuilder()
                 .withId(new GameId("1eec1c19-25bf-4094-b926-84b5bb8fa281"))
                 .withTitle(new GameTitle("Game 1"))
@@ -511,8 +477,6 @@ abstract class FileCopyJpaRepositoryIT {
     }
 
     private static class SampleSourceFiles {
-
-        public static final SourceFileJpaEntityMapper MAPPER = Mappers.getMapper(SourceFileJpaEntityMapper.class);
 
         public static final Supplier<SourceFile> GOG_SOURCE_FILE_1_FOR_GAME_1 = () -> TestSourceFile.gogBuilder()
                 .id(new SourceFileId("acde26d7-33c7-42ee-be16-bca91a604b48"))
@@ -564,8 +528,6 @@ abstract class FileCopyJpaRepositoryIT {
         public static final Supplier<BackupTarget> LOCAL_FOLDER_8 = () -> TestBackupTarget.localFolderBuilder()
                 .withId(new BackupTargetId("03468b45-7152-4026-b416-6a2602bf0c1c"))
                 .build();
-
-        private static final BackupTargetJpaEntityMapper MAPPER = Mappers.getMapper(BackupTargetJpaEntityMapper.class);
 
         public static List<BackupTarget> getAll() {
             return List.of(

--- a/backend/src/test/java/dev/codesoapbox/backity/core/game/infrastructure/adapters/driven/persistence/jpa/GameDirectJpaPersistenceStrategy.java
+++ b/backend/src/test/java/dev/codesoapbox/backity/core/game/infrastructure/adapters/driven/persistence/jpa/GameDirectJpaPersistenceStrategy.java
@@ -2,21 +2,35 @@ package dev.codesoapbox.backity.core.game.infrastructure.adapters.driven.persist
 
 import dev.codesoapbox.backity.core.game.domain.Game;
 import dev.codesoapbox.backity.testing.jpa.DirectJpaPersistenceStrategy;
+import lombok.RequiredArgsConstructor;
 import org.springframework.boot.jpa.test.autoconfigure.TestEntityManager;
 
-@SuppressWarnings("unused")
-public class GameDirectJpaPersistenceStrategy extends DirectJpaPersistenceStrategy<Game, GameJpaEntity> {
+@SuppressWarnings("unused") // Used via component scanning
+@RequiredArgsConstructor
+public class GameDirectJpaPersistenceStrategy implements DirectJpaPersistenceStrategy<Game, GameJpaEntity> {
 
-    public GameDirectJpaPersistenceStrategy(
-            TestEntityManager entityManager,
-            GameJpaEntityMapper entityMapper
-    ) {
-        super(
-                entityManager,
-                entityMapper::toEntity,
-                entityMapper::toDomain,
-                (em, obj) -> em.find(GameJpaEntity.class, obj.getId().value()),
-                Game.class
+    private final GameJpaEntityMapper entityMapper;
+
+    @Override
+    public Class<Game> getDomainObjectClass() {
+        return Game.class;
+    }
+
+    @Override
+    public GameJpaEntity toEntity(Game domainObject) {
+        return entityMapper.toEntity(domainObject);
+    }
+
+    @Override
+    public Game toDomain(GameJpaEntity entity) {
+        return entityMapper.toDomain(entity);
+    }
+
+    @Override
+    public GameJpaEntity findPersistedEntity(TestEntityManager entityManager, Game domainObject) {
+        return entityManager.find(
+                GameJpaEntity.class,
+                domainObject.getId().value()
         );
     }
 }

--- a/backend/src/test/java/dev/codesoapbox/backity/core/game/infrastructure/adapters/driven/persistence/jpa/GameDirectJpaPersistenceStrategy.java
+++ b/backend/src/test/java/dev/codesoapbox/backity/core/game/infrastructure/adapters/driven/persistence/jpa/GameDirectJpaPersistenceStrategy.java
@@ -1,0 +1,22 @@
+package dev.codesoapbox.backity.core.game.infrastructure.adapters.driven.persistence.jpa;
+
+import dev.codesoapbox.backity.core.game.domain.Game;
+import dev.codesoapbox.backity.testing.jpa.DirectJpaPersistenceStrategy;
+import org.springframework.boot.jpa.test.autoconfigure.TestEntityManager;
+
+@SuppressWarnings("unused")
+public class GameDirectJpaPersistenceStrategy extends DirectJpaPersistenceStrategy<Game, GameJpaEntity> {
+
+    public GameDirectJpaPersistenceStrategy(
+            TestEntityManager entityManager,
+            GameJpaEntityMapper entityMapper
+    ) {
+        super(
+                entityManager,
+                entityMapper::toEntity,
+                entityMapper::toDomain,
+                (em, obj) -> em.find(GameJpaEntity.class, obj.getId().value()),
+                Game.class
+        );
+    }
+}

--- a/backend/src/test/java/dev/codesoapbox/backity/core/game/infrastructure/adapters/driven/persistence/jpa/GameJpaRepositoryIT.java
+++ b/backend/src/test/java/dev/codesoapbox/backity/core/game/infrastructure/adapters/driven/persistence/jpa/GameJpaRepositoryIT.java
@@ -7,7 +7,7 @@ import dev.codesoapbox.backity.core.game.domain.TestGame;
 import dev.codesoapbox.backity.core.game.domain.exceptions.GameNotFoundException;
 import dev.codesoapbox.backity.shared.domain.Page;
 import dev.codesoapbox.backity.shared.domain.Pagination;
-import dev.codesoapbox.backity.testing.jpa.TestJpaPersistenceAdapter;
+import dev.codesoapbox.backity.testing.jpa.DirectJpaPersistenceAdapter;
 import dev.codesoapbox.backity.testing.jpa.annotations.MultiDatabaseRepositoryTest;
 import dev.codesoapbox.backity.testing.jpa.extensions.EntityAuditControl;
 import dev.codesoapbox.backity.testing.time.FakeClock;
@@ -39,23 +39,15 @@ abstract class GameJpaRepositoryIT {
     private TestEntityManager entityManager;
 
     @Autowired
-    private GameJpaEntityMapper entityMapper;
+    private FakeClock clock;
 
     @Autowired
-    private FakeClock clock;
-    
-    private TestJpaPersistenceAdapter<Game, GameJpaEntity> gameJpaAdapter;
+    private DirectJpaPersistenceAdapter directPersistenceAdapter;
 
     @SuppressWarnings("JUnitMalformedDeclaration")
     @BeforeEach
     void setUp(EntityAuditControl entityAuditControl) {
         entityAuditControl.disable();
-        gameJpaAdapter = new TestJpaPersistenceAdapter<>(
-                entityManager,
-                entityMapper::toEntity,
-                entityMapper::toDomain,
-                (em, obj) -> em.find(GameJpaEntity.class, obj.getId().value())
-        );
     }
 
     @Test
@@ -68,7 +60,7 @@ abstract class GameJpaRepositoryIT {
         repository.save(game);
         entityManager.flush();
 
-        Game persistedAggregate = gameJpaAdapter.getPersistedDomainObject(game);
+        Game persistedAggregate = directPersistenceAdapter.getPersistedDomainObject(game);
         assertThat(persistedAggregate)
                 .usingRecursiveComparison()
                 .isEqualTo(game);
@@ -88,9 +80,9 @@ abstract class GameJpaRepositoryIT {
         assertThatThrownBy(() -> entityManager.flush())
                 .isInstanceOf(ConstraintViolationException.class);
     }
-    
+
     void persistSampleData() {
-        gameJpaAdapter.persist(SampleGames.getAll());
+        directPersistenceAdapter.persist(SampleGames.getAll());
     }
 
     @Test
@@ -102,7 +94,7 @@ abstract class GameJpaRepositoryIT {
         repository.save(game);
         entityManager.flush();
 
-        Game persistedAggregate = gameJpaAdapter.getPersistedDomainObject(game);
+        Game persistedAggregate = directPersistenceAdapter.getPersistedDomainObject(game);
         assertThat(persistedAggregate)
                 .usingRecursiveComparison()
                 .isEqualTo(game);
@@ -118,7 +110,7 @@ abstract class GameJpaRepositoryIT {
         entityManager.flush();
 
         LocalDateTime now = LocalDateTime.now(clock);
-        Game persistedAggregate = gameJpaAdapter.getPersistedDomainObject(game);
+        Game persistedAggregate = directPersistenceAdapter.getPersistedDomainObject(game);
         assertThat(persistedAggregate.getDateCreated())
                 .isNotEqualTo(game.getDateCreated())
                 .isEqualTo(now);
@@ -139,7 +131,7 @@ abstract class GameJpaRepositoryIT {
         entityManager.flush();
 
         LocalDateTime now = LocalDateTime.now(clock);
-        Game persistedAggregate = gameJpaAdapter.getPersistedDomainObject(game);
+        Game persistedAggregate = directPersistenceAdapter.getPersistedDomainObject(game);
         assertThat(persistedAggregate.getDateCreated())
                 .isEqualTo(game.getDateCreated())
                 .isNotEqualTo(now);

--- a/backend/src/test/java/dev/codesoapbox/backity/core/game/infrastructure/adapters/driven/persistence/jpa/readmodel/GameWithFileCopiesReadModelJpaRepositoryIT.java
+++ b/backend/src/test/java/dev/codesoapbox/backity/core/game/infrastructure/adapters/driven/persistence/jpa/readmodel/GameWithFileCopiesReadModelJpaRepositoryIT.java
@@ -3,11 +3,7 @@ package dev.codesoapbox.backity.core.game.infrastructure.adapters.driven.persist
 import dev.codesoapbox.backity.core.backuptarget.domain.BackupTarget;
 import dev.codesoapbox.backity.core.backuptarget.domain.BackupTargetId;
 import dev.codesoapbox.backity.core.backuptarget.domain.TestBackupTarget;
-import dev.codesoapbox.backity.core.backuptarget.infrastructure.adapters.driven.persistence.jpa.BackupTargetJpaEntity;
-import dev.codesoapbox.backity.core.backuptarget.infrastructure.adapters.driven.persistence.jpa.BackupTargetJpaEntityMapper;
 import dev.codesoapbox.backity.core.filecopy.domain.*;
-import dev.codesoapbox.backity.core.filecopy.infrastructure.adapters.driven.persistence.jpa.FileCopyJpaEntity;
-import dev.codesoapbox.backity.core.filecopy.infrastructure.adapters.driven.persistence.jpa.FileCopyJpaEntityMapper;
 import dev.codesoapbox.backity.core.game.application.GameWithFileCopiesSearchFilter;
 import dev.codesoapbox.backity.core.game.application.TestGameWithFileCopiesSearchFilter;
 import dev.codesoapbox.backity.core.game.application.readmodel.*;
@@ -15,14 +11,10 @@ import dev.codesoapbox.backity.core.game.domain.Game;
 import dev.codesoapbox.backity.core.game.domain.GameId;
 import dev.codesoapbox.backity.core.game.domain.GameTitle;
 import dev.codesoapbox.backity.core.game.domain.TestGame;
-import dev.codesoapbox.backity.core.game.infrastructure.adapters.driven.persistence.jpa.GameJpaEntity;
-import dev.codesoapbox.backity.core.game.infrastructure.adapters.driven.persistence.jpa.GameJpaEntityMapper;
 import dev.codesoapbox.backity.core.sourcefile.domain.*;
-import dev.codesoapbox.backity.core.sourcefile.infrastructure.adapters.driven.persistence.jpa.SourceFileJpaEntity;
-import dev.codesoapbox.backity.core.sourcefile.infrastructure.adapters.driven.persistence.jpa.SourceFileJpaEntityMapper;
 import dev.codesoapbox.backity.shared.domain.Page;
 import dev.codesoapbox.backity.shared.domain.Pagination;
-import dev.codesoapbox.backity.testing.jpa.TestJpaPersistenceAdapter;
+import dev.codesoapbox.backity.testing.jpa.DirectJpaPersistenceAdapter;
 import dev.codesoapbox.backity.testing.jpa.annotations.MultiDatabaseRepositoryTest;
 import dev.codesoapbox.backity.testing.jpa.extensions.EntityAuditControl;
 import dev.codesoapbox.backity.testing.time.config.FakeTimeBeanConfig;
@@ -33,7 +25,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.NullSource;
 import org.junit.jupiter.params.provider.ValueSource;
-import org.mapstruct.factory.Mappers;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.jpa.test.autoconfigure.TestEntityManager;
 import org.springframework.transaction.annotation.Transactional;
@@ -114,47 +105,21 @@ abstract class GameWithFileCopiesReadModelJpaRepositoryIT {
     @Autowired
     private TestEntityManager entityManager;
 
-    private TestJpaPersistenceAdapter<Game, GameJpaEntity> gameJpaAdapter;
-    private TestJpaPersistenceAdapter<SourceFile, SourceFileJpaEntity> sourceFileJpaAdapter;
-    private TestJpaPersistenceAdapter<BackupTarget, BackupTargetJpaEntity> backupTargetJpaAdapter;
-    private TestJpaPersistenceAdapter<FileCopy, FileCopyJpaEntity> fileCopyJpaAdapter;
+    @Autowired
+    private DirectJpaPersistenceAdapter directPersistenceAdapter;
 
     @SuppressWarnings("JUnitMalformedDeclaration")
     @BeforeEach
     void setUp(EntityAuditControl entityAuditControl) {
         entityAuditControl.disable();
-        fileCopyJpaAdapter = new TestJpaPersistenceAdapter<>(
-                entityManager,
-                SampleFileCopies.MAPPER::toEntity,
-                SampleFileCopies.MAPPER::toDomain,
-                (em, obj) -> em.find(FileCopyJpaEntity.class, obj.getId().value())
-        );
-        gameJpaAdapter = new TestJpaPersistenceAdapter<>(
-                entityManager,
-                SampleGames.MAPPER::toEntity,
-                SampleGames.MAPPER::toDomain,
-                (em, obj) -> em.find(GameJpaEntity.class, obj.getId().value())
-        );
-        sourceFileJpaAdapter = new TestJpaPersistenceAdapter<>(
-                entityManager,
-                SampleSourceFiles.MAPPER::toEntity,
-                SampleSourceFiles.MAPPER::toDomain,
-                (em, obj) -> em.find(SourceFileJpaEntity.class, obj.getId().value())
-        );
-        backupTargetJpaAdapter = new TestJpaPersistenceAdapter<>(
-                entityManager,
-                SampleBackupTargets.MAPPER::toEntity,
-                SampleBackupTargets.MAPPER::toDomain,
-                (em, obj) -> em.find(BackupTargetJpaEntity.class, obj.getId().value())
-        );
         persistSampleData();
     }
 
     private void persistSampleData() {
-        gameJpaAdapter.persist(SampleGames.getAll());
-        sourceFileJpaAdapter.persist(SampleSourceFiles.getAll());
-        backupTargetJpaAdapter.persist(SampleBackupTargets.getAll());
-        fileCopyJpaAdapter.persist(SampleFileCopies.getAll());
+        directPersistenceAdapter.persist(SampleGames.getAll());
+        directPersistenceAdapter.persist(SampleSourceFiles.getAll());
+        directPersistenceAdapter.persist(SampleBackupTargets.getAll());
+        directPersistenceAdapter.persist(SampleFileCopies.getAll());
     }
 
     @ParameterizedTest
@@ -399,8 +364,6 @@ abstract class GameWithFileCopiesReadModelJpaRepositoryIT {
                 .withDateCreated(Time.TWO_DAYS_AGO.atStartOfDay())
                 .build();
 
-        private static final GameJpaEntityMapper MAPPER = Mappers.getMapper(GameJpaEntityMapper.class);
-
         public static List<Game> getAll() {
             return List.of(
                     GAME_1_CREATED_TODAY,
@@ -444,8 +407,6 @@ abstract class GameWithFileCopiesReadModelJpaRepositoryIT {
                 .originalFileName(new FileName("game_3.exe"))
                 .build();
 
-        private static final SourceFileJpaEntityMapper MAPPER = Mappers.getMapper(SourceFileJpaEntityMapper.class);
-
         public static List<SourceFile> getAll() {
             return List.of(
                     GOG_SOURCE_FILE_1_FOR_GAME_1,
@@ -457,8 +418,6 @@ abstract class GameWithFileCopiesReadModelJpaRepositoryIT {
     }
 
     private static class SampleBackupTargets {
-
-        public static final BackupTargetJpaEntityMapper MAPPER = Mappers.getMapper(BackupTargetJpaEntityMapper.class);
 
         public static final Supplier<BackupTarget> LOCAL_FOLDER_1 = () -> TestBackupTarget.localFolderBuilder()
                 .withId(new BackupTargetId("eda52c13-ddf7-406f-97d9-d3ce2cab5a76"))
@@ -527,8 +486,6 @@ abstract class GameWithFileCopiesReadModelJpaRepositoryIT {
                         ))
                         .dateModified(Time.TODAY.atStartOfDay())
                         .build();
-
-        private static final FileCopyJpaEntityMapper MAPPER = Mappers.getMapper(FileCopyJpaEntityMapper.class);
 
         public static List<FileCopy> getAll() {
             return List.of(

--- a/backend/src/test/java/dev/codesoapbox/backity/core/sourcefile/infrastructure/adapters/driven/persistence/jpa/SourceFileDirectJpaPersistenceStrategy.java
+++ b/backend/src/test/java/dev/codesoapbox/backity/core/sourcefile/infrastructure/adapters/driven/persistence/jpa/SourceFileDirectJpaPersistenceStrategy.java
@@ -1,0 +1,23 @@
+package dev.codesoapbox.backity.core.sourcefile.infrastructure.adapters.driven.persistence.jpa;
+
+import dev.codesoapbox.backity.core.sourcefile.domain.SourceFile;
+import dev.codesoapbox.backity.testing.jpa.DirectJpaPersistenceStrategy;
+import org.springframework.boot.jpa.test.autoconfigure.TestEntityManager;
+
+@SuppressWarnings("unused")
+public class SourceFileDirectJpaPersistenceStrategy
+        extends DirectJpaPersistenceStrategy<SourceFile, SourceFileJpaEntity> {
+
+    public SourceFileDirectJpaPersistenceStrategy(
+            TestEntityManager entityManager,
+            SourceFileJpaEntityMapper entityMapper
+    ) {
+        super(
+                entityManager,
+                entityMapper::toEntity,
+                entityMapper::toDomain,
+                (em, obj) -> em.find(SourceFileJpaEntity.class, obj.getId().value()),
+                SourceFile.class
+        );
+    }
+}

--- a/backend/src/test/java/dev/codesoapbox/backity/core/sourcefile/infrastructure/adapters/driven/persistence/jpa/SourceFileDirectJpaPersistenceStrategy.java
+++ b/backend/src/test/java/dev/codesoapbox/backity/core/sourcefile/infrastructure/adapters/driven/persistence/jpa/SourceFileDirectJpaPersistenceStrategy.java
@@ -2,22 +2,36 @@ package dev.codesoapbox.backity.core.sourcefile.infrastructure.adapters.driven.p
 
 import dev.codesoapbox.backity.core.sourcefile.domain.SourceFile;
 import dev.codesoapbox.backity.testing.jpa.DirectJpaPersistenceStrategy;
+import lombok.RequiredArgsConstructor;
 import org.springframework.boot.jpa.test.autoconfigure.TestEntityManager;
 
-@SuppressWarnings("unused")
+@SuppressWarnings("unused") // Used via component scanning
+@RequiredArgsConstructor
 public class SourceFileDirectJpaPersistenceStrategy
-        extends DirectJpaPersistenceStrategy<SourceFile, SourceFileJpaEntity> {
+        implements DirectJpaPersistenceStrategy<SourceFile, SourceFileJpaEntity> {
 
-    public SourceFileDirectJpaPersistenceStrategy(
-            TestEntityManager entityManager,
-            SourceFileJpaEntityMapper entityMapper
-    ) {
-        super(
-                entityManager,
-                entityMapper::toEntity,
-                entityMapper::toDomain,
-                (em, obj) -> em.find(SourceFileJpaEntity.class, obj.getId().value()),
-                SourceFile.class
+    private final SourceFileJpaEntityMapper entityMapper;
+
+    @Override
+    public Class<SourceFile> getDomainObjectClass() {
+        return SourceFile.class;
+    }
+
+    @Override
+    public SourceFileJpaEntity toEntity(SourceFile domainObject) {
+        return entityMapper.toEntity(domainObject);
+    }
+
+    @Override
+    public SourceFile toDomain(SourceFileJpaEntity entity) {
+        return entityMapper.toDomain(entity);
+    }
+
+    @Override
+    public SourceFileJpaEntity findPersistedEntity(TestEntityManager entityManager, SourceFile domainObject) {
+        return entityManager.find(
+                SourceFileJpaEntity.class,
+                domainObject.getId().value()
         );
     }
 }

--- a/backend/src/test/java/dev/codesoapbox/backity/core/sourcefile/infrastructure/adapters/driven/persistence/jpa/SourceFileJpaRepositoryIT.java
+++ b/backend/src/test/java/dev/codesoapbox/backity/core/sourcefile/infrastructure/adapters/driven/persistence/jpa/SourceFileJpaRepositoryIT.java
@@ -3,18 +3,15 @@ package dev.codesoapbox.backity.core.sourcefile.infrastructure.adapters.driven.p
 import dev.codesoapbox.backity.core.game.domain.Game;
 import dev.codesoapbox.backity.core.game.domain.GameId;
 import dev.codesoapbox.backity.core.game.domain.GameTitle;
-import dev.codesoapbox.backity.core.game.infrastructure.adapters.driven.persistence.jpa.GameJpaEntity;
-import dev.codesoapbox.backity.core.game.infrastructure.adapters.driven.persistence.jpa.GameJpaEntityMapper;
 import dev.codesoapbox.backity.core.sourcefile.domain.*;
 import dev.codesoapbox.backity.core.sourcefile.domain.exceptions.SourceFileNotFoundException;
-import dev.codesoapbox.backity.testing.jpa.TestJpaPersistenceAdapter;
+import dev.codesoapbox.backity.testing.jpa.DirectJpaPersistenceAdapter;
 import dev.codesoapbox.backity.testing.jpa.annotations.MultiDatabaseRepositoryTest;
 import dev.codesoapbox.backity.testing.jpa.extensions.EntityAuditControl;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
-import org.mapstruct.factory.Mappers;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.jpa.test.autoconfigure.TestEntityManager;
 import org.springframework.transaction.annotation.Transactional;
@@ -40,30 +37,15 @@ abstract class SourceFileJpaRepositoryIT {
     protected TestEntityManager entityManager;
 
     @Autowired
-    protected SourceFileJpaEntityMapper entityMapper;
-
-    @Autowired
     protected Clock clock;
 
-    private TestJpaPersistenceAdapter<SourceFile, SourceFileJpaEntity> sourceFileJpaAdapter;
-    private TestJpaPersistenceAdapter<Game, GameJpaEntity> gameJpaAdapter;
+    @Autowired
+    private DirectJpaPersistenceAdapter directPersistenceAdapter;
 
     @SuppressWarnings("JUnitMalformedDeclaration")
     @BeforeEach
     void setUp(EntityAuditControl entityAuditControl) {
         entityAuditControl.disable();
-        sourceFileJpaAdapter = new TestJpaPersistenceAdapter<>(
-                entityManager,
-                entityMapper::toEntity,
-                entityMapper::toDomain,
-                (em, obj) -> em.find(SourceFileJpaEntity.class, obj.getId().value())
-        );
-        gameJpaAdapter = new TestJpaPersistenceAdapter<>(
-                entityManager,
-                SampleGames.MAPPER::toEntity,
-                SampleGames.MAPPER::toDomain,
-                (em, obj) -> em.find(GameJpaEntity.class, obj.getId().value())
-        );
     }
 
     @Test
@@ -74,14 +56,14 @@ abstract class SourceFileJpaRepositoryIT {
         repository.save(sourceFile);
         entityManager.flush();
 
-        SourceFile persistedAggregate = sourceFileJpaAdapter.getPersistedDomainObject(sourceFile);
+        SourceFile persistedAggregate = directPersistenceAdapter.getPersistedDomainObject(sourceFile);
         assertThat(persistedAggregate)
                 .usingRecursiveComparison()
                 .isEqualTo(sourceFile);
     }
 
     private void persistSampleDependencies() {
-        gameJpaAdapter.persist(SampleGames.getAll());
+        directPersistenceAdapter.persist(SampleGames.getAll());
     }
 
     @Test
@@ -93,7 +75,7 @@ abstract class SourceFileJpaRepositoryIT {
         repository.save(sourceFile);
         entityManager.flush();
 
-        SourceFile persistedAggregate = sourceFileJpaAdapter.getPersistedDomainObject(sourceFile);
+        SourceFile persistedAggregate = directPersistenceAdapter.getPersistedDomainObject(sourceFile);
         assertThat(persistedAggregate)
                 .usingRecursiveComparison()
                 .isEqualTo(sourceFile);
@@ -101,7 +83,7 @@ abstract class SourceFileJpaRepositoryIT {
 
     void persistSampleData() {
         persistSampleDependencies();
-        sourceFileJpaAdapter.persist(SampleSourceFiles.getAll());
+        directPersistenceAdapter.persist(SampleSourceFiles.getAll());
     }
 
     @SuppressWarnings("JUnitMalformedDeclaration")
@@ -115,7 +97,7 @@ abstract class SourceFileJpaRepositoryIT {
         entityManager.flush();
 
         LocalDateTime now = LocalDateTime.now(clock);
-        SourceFile persistedAggregate = sourceFileJpaAdapter.getPersistedDomainObject(sourceFile);
+        SourceFile persistedAggregate = directPersistenceAdapter.getPersistedDomainObject(sourceFile);
         assertThat(persistedAggregate.getDateCreated())
                 .isNotEqualTo(sourceFile.getDateCreated())
                 .isEqualTo(now);
@@ -136,7 +118,7 @@ abstract class SourceFileJpaRepositoryIT {
         entityManager.flush();
 
         LocalDateTime now = LocalDateTime.now(clock);
-        SourceFile persistedAggregate = sourceFileJpaAdapter.getPersistedDomainObject(sourceFile);
+        SourceFile persistedAggregate = directPersistenceAdapter.getPersistedDomainObject(sourceFile);
         assertThat(persistedAggregate.getDateCreated())
                 .isEqualTo(sourceFile.getDateCreated())
                 .isNotEqualTo(now);
@@ -149,7 +131,7 @@ abstract class SourceFileJpaRepositoryIT {
     @CsvSource(value = {"1.0.0,true", "fakeVersion,false"})
     void existsByUrlAndVersion(String versionValue, boolean shouldFind) {
         persistSampleDependencies();
-        sourceFileJpaAdapter.persist(SampleSourceFiles.getAll());
+        directPersistenceAdapter.persist(SampleSourceFiles.getAll());
         var version = new FileVersion(versionValue);
         var url = new SourceFileUrl("/downlink/some_game/some_file");
 
@@ -161,7 +143,7 @@ abstract class SourceFileJpaRepositoryIT {
     @Test
     void findByIdShouldReturnAggregateGivenItExists() {
         persistSampleDependencies();
-        sourceFileJpaAdapter.persist(SampleSourceFiles.getAll());
+        directPersistenceAdapter.persist(SampleSourceFiles.getAll());
         SourceFile expectedSourceFile = SampleSourceFiles.GOG_SOURCE_FILE_1_FOR_GAME_1.get();
 
         Optional<SourceFile> result = repository.findById(expectedSourceFile.getId());
@@ -184,7 +166,7 @@ abstract class SourceFileJpaRepositoryIT {
     @Test
     void getByIdShouldReturnAggregateGivenItExists() {
         persistSampleDependencies();
-        sourceFileJpaAdapter.persist(SampleSourceFiles.getAll());
+        directPersistenceAdapter.persist(SampleSourceFiles.getAll());
         SourceFile expectedSourceFile = SampleSourceFiles.GOG_SOURCE_FILE_1_FOR_GAME_1.get();
 
         SourceFile result = repository.getById(expectedSourceFile.getId());
@@ -204,7 +186,7 @@ abstract class SourceFileJpaRepositoryIT {
     @Test
     void findAllByGameIdShouldReturnAllDataForAggregate() {
         persistSampleDependencies();
-        sourceFileJpaAdapter.persist(SampleSourceFiles.getAll());
+        directPersistenceAdapter.persist(SampleSourceFiles.getAll());
         List<SourceFile> result = repository.findAllByGameId(SampleGames.GAME_1.getId());
 
         assertThat(result)
@@ -218,7 +200,7 @@ abstract class SourceFileJpaRepositoryIT {
     @Test
     void findAllByIdInShouldReturnAllDataForAggregate() {
         persistSampleDependencies();
-        sourceFileJpaAdapter.persist(SampleSourceFiles.getAll());
+        directPersistenceAdapter.persist(SampleSourceFiles.getAll());
         SourceFile expectedSourceFile = SampleSourceFiles.GOG_SOURCE_FILE_1_FOR_GAME_1.get();
 
         List<SourceFile> result = repository.findAllByIdIn(List.of(expectedSourceFile.getId()));
@@ -232,16 +214,14 @@ abstract class SourceFileJpaRepositoryIT {
     void deleteByIdShouldDeleteAggregate() {
         persistSampleDependencies();
         SourceFile sourceFile = SampleSourceFiles.GOG_SOURCE_FILE_1_FOR_GAME_1.get();
-        sourceFileJpaAdapter.persist(sourceFile);
+        directPersistenceAdapter.persist(sourceFile);
 
         repository.deleteById(sourceFile.getId());
 
-        assertThat(sourceFileJpaAdapter.exists(sourceFile)).isFalse();
+        assertThat(directPersistenceAdapter.exists(sourceFile)).isFalse();
     }
 
     private static class SampleGames {
-
-        public static final GameJpaEntityMapper MAPPER = Mappers.getMapper(GameJpaEntityMapper.class);
 
         public static final Game GAME_1 = anyBuilder()
                 .withId(new GameId("1eec1c19-25bf-4094-b926-84b5bb8fa281"))

--- a/backend/src/test/java/dev/codesoapbox/backity/testing/jpa/DirectJpaPersistenceAdapter.java
+++ b/backend/src/test/java/dev/codesoapbox/backity/testing/jpa/DirectJpaPersistenceAdapter.java
@@ -1,46 +1,102 @@
 package dev.codesoapbox.backity.testing.jpa;
 
+import org.springframework.boot.jpa.test.autoconfigure.TestEntityManager;
+
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
-/// Allows interacting with the database directly through simple JPA queries,
+/// Allows interacting with the database directly through simple JPA queries
 /// so that repository tests can be made completely independent of each other.
 public class DirectJpaPersistenceAdapter {
 
-    private final Map<Class<?>, DirectJpaPersistenceStrategy<?, ?>> persistenceAdaptersByEntityClass;
+    private final TestEntityManager entityManager;
+
+    private final Map<Class<?>, DirectJpaPersistenceStrategy<?, ?>> strategiesByDomainClass;
 
     public DirectJpaPersistenceAdapter(
-            List<DirectJpaPersistenceStrategy<?, ?>> persistenceAdapters
+            TestEntityManager entityManager,
+            List<DirectJpaPersistenceStrategy<?, ?>> strategies
     ) {
-        persistenceAdaptersByEntityClass = persistenceAdapters.stream()
-                .collect(Collectors.toMap(DirectJpaPersistenceStrategy::getDomainObjectClass, Function.identity()));
+        this.entityManager = entityManager;
+
+        this.strategiesByDomainClass = strategies.stream()
+                .collect(Collectors.toMap(
+                        DirectJpaPersistenceStrategy::getDomainObjectClass,
+                        Function.identity()
+                ));
     }
 
     @SafeVarargs
     public final <T> void persist(T... domainObjects) {
-        DirectJpaPersistenceStrategy<T, ?> adapter = getPersistenceAdapterFor(domainObjects[0]);
-        adapter.persist(domainObjects);
+        if (domainObjects == null || domainObjects.length == 0) {
+            throw new IllegalArgumentException("At least one domain object is required");
+        }
+
+        DirectJpaPersistenceStrategy<T, ?> strategy = getStrategyFor(domainObjects[0]);
+
+        for (T domainObject : domainObjects) {
+            entityManager.persist(strategy.toEntity(domainObject));
+        }
+
+        entityManager.flush();
     }
 
-    @SuppressWarnings("unchecked") // Safe cast
-    private <T, E> DirectJpaPersistenceStrategy<T, E> getPersistenceAdapterFor(T domainObject) {
-        return (DirectJpaPersistenceStrategy<T, E>) persistenceAdaptersByEntityClass.get(domainObject.getClass());
+    @SuppressWarnings("unchecked")
+    private <T, E> DirectJpaPersistenceStrategy<T, E> getStrategyFor(T domainObject) {
+        if (domainObject == null) {
+            throw new IllegalArgumentException("domainObject must not be null");
+        }
+
+        DirectJpaPersistenceStrategy<?, ?> strategy = strategiesByDomainClass.get(domainObject.getClass());
+
+        if (strategy == null) {
+            throw new IllegalStateException(
+                    "No %s registered for %s".formatted(
+                            DirectJpaPersistenceStrategy.class.getSimpleName(),
+                            domainObject.getClass().getName()
+                    )
+            );
+        }
+
+        return (DirectJpaPersistenceStrategy<T, E>)
+                strategiesByDomainClass.get(domainObject.getClass());
     }
 
     public <T> void persist(List<T> domainObjects) {
-        DirectJpaPersistenceStrategy<T, ?> adapter = getPersistenceAdapterFor(domainObjects.getFirst());
-        adapter.persist(domainObjects);
+        if (domainObjects == null || domainObjects.isEmpty()) {
+            throw new IllegalArgumentException("At least one domain object is required");
+        }
+
+        DirectJpaPersistenceStrategy<T, ?> strategy = getStrategyFor(domainObjects.getFirst());
+
+        domainObjects.forEach(
+                domainObject -> entityManager.persist(strategy.toEntity(domainObject))
+        );
+
+        entityManager.flush();
     }
 
-    public <T, E> T getPersistedDomainObject(T domainObject) {
-        DirectJpaPersistenceStrategy<T, E> adapter = getPersistenceAdapterFor(domainObject);
-        return adapter.getPersistedDomainObject(domainObject);
+    public <T> T getPersistedDomainObject(T domainObject) {
+        DirectJpaPersistenceStrategy<T, ?> strategy = getStrategyFor(domainObject);
+
+        Object entity = strategy.findPersistedEntity(entityManager, domainObject);
+
+        return entity == null
+                ? null
+                : strategy.toDomain(cast(entity));
+    }
+
+    @SuppressWarnings("unchecked")
+    private <E> E cast(Object entity) {
+        return (E) entity;
     }
 
     public <T> boolean exists(T domainObject) {
-        DirectJpaPersistenceStrategy<T, ?> adapter = getPersistenceAdapterFor(domainObject);
-        return adapter.exists(domainObject);
+        DirectJpaPersistenceStrategy<T, ?> strategy =
+                getStrategyFor(domainObject);
+
+        return strategy.findPersistedEntity(entityManager, domainObject) != null;
     }
 }

--- a/backend/src/test/java/dev/codesoapbox/backity/testing/jpa/DirectJpaPersistenceAdapter.java
+++ b/backend/src/test/java/dev/codesoapbox/backity/testing/jpa/DirectJpaPersistenceAdapter.java
@@ -1,0 +1,46 @@
+package dev.codesoapbox.backity.testing.jpa;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+/// Allows interacting with the database directly through simple JPA queries,
+/// so that repository tests can be made completely independent of each other.
+public class DirectJpaPersistenceAdapter {
+
+    private final Map<Class<?>, DirectJpaPersistenceStrategy<?, ?>> persistenceAdaptersByEntityClass;
+
+    public DirectJpaPersistenceAdapter(
+            List<DirectJpaPersistenceStrategy<?, ?>> persistenceAdapters
+    ) {
+        persistenceAdaptersByEntityClass = persistenceAdapters.stream()
+                .collect(Collectors.toMap(DirectJpaPersistenceStrategy::getDomainObjectClass, Function.identity()));
+    }
+
+    @SafeVarargs
+    public final <T> void persist(T... domainObjects) {
+        DirectJpaPersistenceStrategy<T, ?> adapter = getPersistenceAdapterFor(domainObjects[0]);
+        adapter.persist(domainObjects);
+    }
+
+    @SuppressWarnings("unchecked") // Safe cast
+    private <T, E> DirectJpaPersistenceStrategy<T, E> getPersistenceAdapterFor(T domainObject) {
+        return (DirectJpaPersistenceStrategy<T, E>) persistenceAdaptersByEntityClass.get(domainObject.getClass());
+    }
+
+    public <T> void persist(List<T> domainObjects) {
+        DirectJpaPersistenceStrategy<T, ?> adapter = getPersistenceAdapterFor(domainObjects.getFirst());
+        adapter.persist(domainObjects);
+    }
+
+    public <T, E> T getPersistedDomainObject(T domainObject) {
+        DirectJpaPersistenceStrategy<T, E> adapter = getPersistenceAdapterFor(domainObject);
+        return adapter.getPersistedDomainObject(domainObject);
+    }
+
+    public <T> boolean exists(T domainObject) {
+        DirectJpaPersistenceStrategy<T, ?> adapter = getPersistenceAdapterFor(domainObject);
+        return adapter.exists(domainObject);
+    }
+}

--- a/backend/src/test/java/dev/codesoapbox/backity/testing/jpa/DirectJpaPersistenceStrategy.java
+++ b/backend/src/test/java/dev/codesoapbox/backity/testing/jpa/DirectJpaPersistenceStrategy.java
@@ -1,61 +1,17 @@
 package dev.codesoapbox.backity.testing.jpa;
 
-import lombok.Getter;
 import org.springframework.boot.jpa.test.autoconfigure.TestEntityManager;
 
-import java.util.List;
-import java.util.function.BiFunction;
-import java.util.function.Function;
-
-/// Allows interacting with specific objects in the database directly through simple JPA queries,
-/// so that repository tests can be made completely independent of each other.
+/// Defines how a domain object maps to a JPA entity and how to find it in the database.
 ///
 /// Used via [DirectJpaPersistenceAdapter].
-public abstract class DirectJpaPersistenceStrategy<T, E> {
+public interface DirectJpaPersistenceStrategy<T, E> {
 
-    private final TestEntityManager entityManager;
-    private final Function<T, E> toEntity;
-    private final Function<E, T> toDomain;
-    private final BiFunction<TestEntityManager, T, E> persistedEntityFinder;
+    Class<T> getDomainObjectClass();
 
-    @Getter
-    private final Class<T> domainObjectClass;
+    E toEntity(T domainObject);
 
-    public DirectJpaPersistenceStrategy(TestEntityManager entityManager,
-                                        Function<T, E> toEntity,
-                                        Function<E, T> toDomain,
-                                        BiFunction<TestEntityManager, T, E> persistedEntityFinder,
-                                        Class<T> domainObjectClass) {
-        this.entityManager = entityManager;
-        this.toEntity = toEntity;
-        this.toDomain = toDomain;
-        this.persistedEntityFinder = persistedEntityFinder;
-        this.domainObjectClass = domainObjectClass;
-    }
+    T toDomain(E entity);
 
-    @SafeVarargs
-    public final void persist(T... domainObjects) {
-        for (T domainObject : domainObjects) {
-            entityManager.persist(toEntity.apply(domainObject));
-        }
-        entityManager.flush();
-    }
-
-    public void persist(List<T> domainObjects) {
-        domainObjects.forEach(domainObject -> entityManager.persist(toEntity.apply(domainObject)));
-        entityManager.flush();
-    }
-
-    public T getPersistedDomainObject(T domainObject) {
-        E persistedEntity = getPersistedEntity(domainObject);
-        return toDomain.apply(persistedEntity);
-    }
-
-    public E getPersistedEntity(T domainObject) {
-        return persistedEntityFinder.apply(entityManager, domainObject);
-    }
-
-    public boolean exists(T domainObject) {
-        return getPersistedEntity(domainObject) != null;
-    }
+    E findPersistedEntity(TestEntityManager entityManager, T domainObject);
 }

--- a/backend/src/test/java/dev/codesoapbox/backity/testing/jpa/DirectJpaPersistenceStrategy.java
+++ b/backend/src/test/java/dev/codesoapbox/backity/testing/jpa/DirectJpaPersistenceStrategy.java
@@ -1,27 +1,36 @@
 package dev.codesoapbox.backity.testing.jpa;
 
+import lombok.Getter;
 import org.springframework.boot.jpa.test.autoconfigure.TestEntityManager;
 
 import java.util.List;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 
-/// Simplifies persistence operations for JPA repository tests
-public class TestJpaPersistenceAdapter<T, E> {
+/// Allows interacting with specific objects in the database directly through simple JPA queries,
+/// so that repository tests can be made completely independent of each other.
+///
+/// Used via [DirectJpaPersistenceAdapter].
+public abstract class DirectJpaPersistenceStrategy<T, E> {
 
     private final TestEntityManager entityManager;
     private final Function<T, E> toEntity;
     private final Function<E, T> toDomain;
     private final BiFunction<TestEntityManager, T, E> persistedEntityFinder;
 
-    public TestJpaPersistenceAdapter(TestEntityManager entityManager,
-                                     Function<T, E> toEntity,
-                                     Function<E, T> toDomain,
-                                     BiFunction<TestEntityManager, T, E> persistedEntityFinder) {
+    @Getter
+    private final Class<T> domainObjectClass;
+
+    public DirectJpaPersistenceStrategy(TestEntityManager entityManager,
+                                        Function<T, E> toEntity,
+                                        Function<E, T> toDomain,
+                                        BiFunction<TestEntityManager, T, E> persistedEntityFinder,
+                                        Class<T> domainObjectClass) {
         this.entityManager = entityManager;
         this.toEntity = toEntity;
         this.toDomain = toDomain;
         this.persistedEntityFinder = persistedEntityFinder;
+        this.domainObjectClass = domainObjectClass;
     }
 
     @SafeVarargs

--- a/backend/src/test/java/dev/codesoapbox/backity/testing/jpa/annotations/JpaRepositoryTest.java
+++ b/backend/src/test/java/dev/codesoapbox/backity/testing/jpa/annotations/JpaRepositoryTest.java
@@ -3,6 +3,8 @@ package dev.codesoapbox.backity.testing.jpa.annotations;
 import dev.codesoapbox.backity.BackityApplication;
 import dev.codesoapbox.backity.shared.infrastructure.config.slices.JpaRepositoryBeanConfiguration;
 import dev.codesoapbox.backity.shared.infrastructure.config.slices.SpringApplicationEventPublisherBeanConfiguration;
+import dev.codesoapbox.backity.testing.jpa.DirectJpaPersistenceStrategy;
+import dev.codesoapbox.backity.testing.jpa.DirectJpaPersistenceAdapter;
 import dev.codesoapbox.backity.testing.jpa.extensions.EntityAuditControlExtension;
 import dev.codesoapbox.backity.testing.mocking.MockBeansMatching;
 import dev.codesoapbox.backity.testing.time.config.FakeTimeBeanConfig;
@@ -45,14 +47,23 @@ import java.lang.annotation.Target;
         mergeMode = TestExecutionListeners.MergeMode.MERGE_WITH_DEFAULTS)
 @Import({
         // Common
-        FakeTimeBeanConfig.class
+        FakeTimeBeanConfig.class,
+
+        // Testing tools
+        DirectJpaPersistenceAdapter.class,
 })
 @ComponentScan(
         basePackageClasses = BackityApplication.class,
-        includeFilters = @ComponentScan.Filter(
-                type = FilterType.ANNOTATION,
-                classes = JpaRepositoryBeanConfiguration.class
-        ),
+        includeFilters = {
+                @ComponentScan.Filter(
+                        type = FilterType.ANNOTATION,
+                        classes = JpaRepositoryBeanConfiguration.class
+                ),
+                @ComponentScan.Filter(
+                        type = FilterType.ASSIGNABLE_TYPE,
+                        classes = DirectJpaPersistenceStrategy.class
+                )
+        },
         useDefaultFilters = false
 )
 @MockBeansMatching(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Refactored JPA repository integration tests to use a new direct persistence adapter approach for seeding data and validating persisted results.
  * Updated multiple repository test suites to query persisted aggregates and existence checks through the shared adapter.

* **Chores**
  * Removed the legacy JPA test persistence utility and replaced it with streamlined, per-aggregate direct persistence strategies.
  * Simplified test setup and sample data persistence across affected test suites.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->